### PR TITLE
Enhance Large Page Support in MSFT OpenJDK for Windows: Multi-Size Page Handling Upgrade

### DIFF
--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -901,7 +901,7 @@ int os::active_processor_count() {
     warning("GetProcessAffinityMask() failed: GetLastError->%ld.", GetLastError());
   }
 
-  // There are no processor affinity restritions at this point so we can return
+  // There are no processor affinity restrictions at this point so we can return
   // the overall processor count if the OS automatically schedules threads across
   // all processors on the system. Note that older operating systems can
   // correctly report processor count but will not schedule threads across
@@ -4129,32 +4129,32 @@ DWORD os::win32::system_logical_processor_count() {
 
   if (glpiex != NULL) {
     LOGICAL_PROCESSOR_RELATIONSHIP relationship_type = RelationGroup;
-    PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX sytem_logical_processor_info = NULL;
+    PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX system_logical_processor_info = NULL;
     DWORD returned_length = 0;
 
     // https://learn.microsoft.com/en-us/windows/win32/api/sysinfoapi/nf-sysinfoapi-getlogicalprocessorinformationex
-    if (!glpiex(relationship_type, sytem_logical_processor_info, &returned_length)) {
+    if (!glpiex(relationship_type, system_logical_processor_info, &returned_length)) {
       DWORD last_error = GetLastError();
 
       if (last_error == ERROR_INSUFFICIENT_BUFFER) {
-        sytem_logical_processor_info = (PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX)os::malloc(returned_length, mtInternal);
+        system_logical_processor_info = (PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX)os::malloc(returned_length, mtInternal);
 
-        if (NULL == sytem_logical_processor_info) {
+        if (NULL == system_logical_processor_info) {
           warning("os::malloc() failed to allocate %ld bytes for GetLogicalProcessorInformationEx buffer", returned_length);
-        } else if (!glpiex(relationship_type, sytem_logical_processor_info, &returned_length)) {
+        } else if (!glpiex(relationship_type, system_logical_processor_info, &returned_length)) {
           warning("GetLogicalProcessorInformationEx() failed: GetLastError->%ld.", GetLastError());
         } else {
-          DWORD processor_groups = sytem_logical_processor_info->Group.ActiveGroupCount;
+          DWORD processor_groups = system_logical_processor_info->Group.ActiveGroupCount;
 
           for (DWORD i = 0; i < processor_groups; i++) {
-            PROCESSOR_GROUP_INFO group_info = sytem_logical_processor_info->Group.GroupInfo[i];
+            PROCESSOR_GROUP_INFO group_info = system_logical_processor_info->Group.GroupInfo[i];
             logical_processors += group_info.ActiveProcessorCount;
           }
 
           assert(logical_processors > 0, "Must find at least 1 logical processor");
         }
 
-        os::free(sytem_logical_processor_info);
+        os::free(system_logical_processor_info);
       }
       else {
         warning("GetLogicalProcessorInformationEx() failed: GetLastError->%ld.", last_error);

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -4118,7 +4118,7 @@ DWORD os::win32::system_logical_processor_count() {
     DWORD returned_length = 0;
 
     // https://learn.microsoft.com/en-us/windows/win32/api/sysinfoapi/nf-sysinfoapi-getlogicalprocessorinformationex
-    if (!glpiex(relationship_type, system_logical_processor_info, &returned_length)) {
+    if (!glpiex(relationship_type, nullptr, &returned_length)) {
       DWORD last_error = GetLastError();
 
       if (last_error == ERROR_INSUFFICIENT_BUFFER) {

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -4070,16 +4070,6 @@ bool os::win32::is_windows_server_2022_or_greater() {
   return (_major_version >= 10 && _build_number >= 20348 && IsWindowsServer());
 }
 
-bool os::win32::schedules_all_processor_groups() {
-  // Starting with Windows 11 and Windows Server 2022 the OS has changed to
-  // make processes and their threads span all processors in the system,
-  // across all processor groups, by default. Therefore, this function needs
-  // to detect Windows 11 or Windows Server 2022. See
-  // https://learn.microsoft.com/en-us/windows/win32/procthread/processor-groups#behavior-starting-with-windows-11-and-windows-server-2022
-
-  return is_windows_11_or_greater() || is_windows_server_2022_or_greater();
-}
-
 DWORD os::win32::get_logical_processor_count() {
   DWORD logicalProcessors = 0;
   typedef BOOL(WINAPI* LPFN_GET_LOGICAL_PROCESSOR_INFORMATION_EX)(
@@ -4139,8 +4129,15 @@ void os::win32::initialize_system_info() {
   _processor_type  = si.dwProcessorType;
   _processor_level = si.wProcessorLevel;
 
+  // Starting with Windows 11 and Windows Server 2022 the OS has changed to
+  // make processes and their threads span all processors in the system,
+  // across all processor groups, by default. Therefore, this function needs
+  // to detect Windows 11 or Windows Server 2022. See
+  // https://learn.microsoft.com/en-us/windows/win32/procthread/processor-groups#behavior-starting-with-windows-11-and-windows-server-2022
+  bool schedules_all_processor_groups = is_windows_11_or_greater() || is_windows_server_2022_or_greater();
+
   DWORD logicalProcessors = 0;
-  if (schedules_all_processor_groups()) {
+  if (schedules_all_processor_groups) {
     logicalProcessors = get_logical_processor_count();
   }
 

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -3216,6 +3216,7 @@ static size_t large_page_init_decide_size() {
                          !FLAG_IS_DEFAULT(LargePageSizeInBytes);
 
 #define WARN(msg) if (warn_on_failure) { warning(msg); }
+#define WARN1(msg,p) if (warn_on_failure) { warning(msg,p); }
 
   if (!request_lock_memory_privilege()) {
     WARN("JVM cannot use large page memory because it does not have enough privilege to lock pages in memory.");
@@ -3228,15 +3229,33 @@ static size_t large_page_init_decide_size() {
     return 0;
   }
 
-#if defined(IA32) || defined(AMD64)
-  if (size > 4*M || LargePageSizeInBytes > 4*M) {
-    WARN("JVM cannot use large pages bigger than 4mb.");
-    return 0;
-  }
+  // Check if OS version is 11 or greater
+  if (schedules_all_processor_groups) {
+      // OS-specific logic for versions 11 or greater
+      // You can implement specific checks or logic here for newer OS versions
+   }
+  else {
+      // Existing logic for OS versions less than 11
+#if defined(IA32)
+      if (size > 4 * M || LargePageSizeInBytes > 4 * M) {
+          WARN("JVM cannot use large pages bigger than 4mb.");
+          return 0;
+      }
+#elif defined(AMD64)
+      if (!EnableAllLargePageSizes) {
+          if (size > 4 * M || LargePageSizeInBytes > 4 * M) {
+              WARN("JVM cannot use large pages bigger than 4mb.");
+              return 0;
+          }
+      }
 #endif
+  }
 
   if (LargePageSizeInBytes > 0 && LargePageSizeInBytes % size == 0) {
-    size = LargePageSizeInBytes;
+      size = LargePageSizeInBytes;
+  }
+  else {
+      WARN1("JVM cannot use large pages that are not a multiple of minimum large page size (%d), defaulting to minimum page size.", size);
   }
 
 #undef WARN
@@ -3252,11 +3271,26 @@ void os::large_page_init() {
   _large_page_size = large_page_init_decide_size();
   const size_t default_page_size = os::vm_page_size();
   if (_large_page_size > default_page_size) {
-    _page_sizes.add(_large_page_size);
-  }
 
+#if !defined(IA32)
+      // Check if the OS version is 11 or higher
+      if (schedules_all_processor_groups && EnableAllLargePageSizes) {
+
+          // Additional logic needed for ARM architecture
+          size_t min_size = GetLargePageMinimum();
+
+          // Populate _page_sizes with large page sizes less than or equal to _large_page_size.
+          for (size_t page_size = min_size; page_size < _large_page_size; page_size *= 2) {
+              _page_sizes.add(page_size);
+          }
+      }
+#endif
+
+      _page_sizes.add(_large_page_size);
+  }
+  // Set UseLargePages based on whether a large page size was successfully determined
   UseLargePages = _large_page_size != 0;
-}
+  }
 
 int os::create_file_for_heap(const char* dir) {
 

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -893,7 +893,7 @@ int os::active_processor_count() {
   if (GetProcessAffinityMask(GetCurrentProcess(), &lpProcessAffinityMask, &lpSystemAffinityMask)) {
     logical_processors = win32::bit_count(lpProcessAffinityMask);
 
-    if (logical_processors != si.dwNumberOfProcessors) {
+    if (logical_processors < si.dwNumberOfProcessors) {
       // Respect the custom processor affinity since it is not equal to all processors in the current processor group
       return logical_processors;
     }

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -4089,7 +4089,7 @@ DWORD os::win32::active_processors_in_job_object() {
 
           os::free(job_object_information);
       } else {
-          warning("os::malloc() failed to allocate %ld bytes for QueryInformationJobObject", job_object_information);
+          warning("os::malloc() failed to allocate %ld bytes for QueryInformationJobObject", job_object_information_length);
       }
     }
   }

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -4083,7 +4083,7 @@ DWORD os::win32::active_processors_in_job_object() {
       job_object_information = os::malloc(job_object_information_length, mtInternal);
       if (job_object_information != NULL) {
           if (QueryInformationJobObject(NULL, JobObjectGroupInformationEx, job_object_information, job_object_information_length, &job_object_information_length)) {
-            group_count = job_object_information_length / sizeof(GROUP_AFFINITY);
+            assert(group_count == job_object_information_length / sizeof(GROUP_AFFINITY));
 
             for (DWORD i = 0; i < group_count; i++) {
               KAFFINITY group_affinity = ((GROUP_AFFINITY*)job_object_information)[i].Mask;

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -4056,19 +4056,15 @@ free_mem:
 }
 
 bool os::win32::is_windows_11_or_greater() {
-  initialize_windows_version();
-
   // Windows 11 starts at build 22000 (Version 21H2) as per
   // https://learn.microsoft.com/en-us/windows/release-health/windows11-release-information
-  return (_major_version >= 10 && _build_number >= 22000 && !IsWindowsServer());
+  return (windows_major_version() >= 10 && windows_build_number() >= 22000 && !IsWindowsServer());
 }
 
 bool os::win32::is_windows_server_2022_or_greater() {
-  initialize_windows_version();
-
   // Windows Server 2022 starts at build 20348.169 as per
   // https://learn.microsoft.com/en-us/windows/release-health/release-information
-  return (_major_version >= 10 && _build_number >= 20348 && IsWindowsServer());
+  return (windows_major_version() >= 10 && windows_build_number() >= 20348 && IsWindowsServer());
 }
 
 int os::win32::bit_count(ULONG64 argument) {

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -4103,7 +4103,7 @@ DWORD os::win32::active_processors_in_job_object() {
 }
 
 DWORD os::win32::system_logical_processor_count() {
-  DWORD logicalProcessors = 0;
+  DWORD logical_processors = 0;
   typedef BOOL(WINAPI* LPFN_GET_LOGICAL_PROCESSOR_INFORMATION_EX)(
       LOGICAL_PROCESSOR_RELATIONSHIP, PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX, PDWORD);
 
@@ -4120,9 +4120,9 @@ DWORD os::win32::system_logical_processor_count() {
 
     // https://learn.microsoft.com/en-us/windows/win32/api/sysinfoapi/nf-sysinfoapi-getlogicalprocessorinformationex
     if (!glpiex(relationshipType, pSytemLogicalProcessorInfo, &returnedLength)) {
-      DWORD lastError = GetLastError();
+      DWORD last_error = GetLastError();
 
-      if (lastError == ERROR_INSUFFICIENT_BUFFER) {
+      if (last_error == ERROR_INSUFFICIENT_BUFFER) {
         pSytemLogicalProcessorInfo = (PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX)os::malloc(returnedLength, mtInternal);
 
         if (NULL == pSytemLogicalProcessorInfo) {
@@ -4130,25 +4130,25 @@ DWORD os::win32::system_logical_processor_count() {
         } else if (!glpiex(relationshipType, pSytemLogicalProcessorInfo, &returnedLength)) {
           warning("GetLogicalProcessorInformationEx() failed: GetLastError->%ld.", GetLastError());
         } else {
-          DWORD processorGroups = pSytemLogicalProcessorInfo->Group.ActiveGroupCount;
+          DWORD processor_groups = pSytemLogicalProcessorInfo->Group.ActiveGroupCount;
 
-          for (DWORD i = 0; i < processorGroups; i++) {
-            PROCESSOR_GROUP_INFO groupInfo = pSytemLogicalProcessorInfo->Group.GroupInfo[i];
-            logicalProcessors += groupInfo.ActiveProcessorCount;
+          for (DWORD i = 0; i < processor_groups; i++) {
+            PROCESSOR_GROUP_INFO group_info = pSytemLogicalProcessorInfo->Group.GroupInfo[i];
+            logical_processors += group_info.ActiveProcessorCount;
           }
 
-          assert(logicalProcessors > 0, "Must find at least 1 logical processor");
+          assert(logical_processors > 0, "Must find at least 1 logical processor");
         }
 
         os::free(pSytemLogicalProcessorInfo);
       }
       else {
-        warning("GetLogicalProcessorInformationEx() failed: GetLastError->%ld.", lastError);
+        warning("GetLogicalProcessorInformationEx() failed: GetLastError->%ld.", last_error);
       }
     }
   }
 
-  return logicalProcessors;
+  return logical_processors;
 }
 
 void os::win32::initialize_system_info() {

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -893,8 +893,14 @@ int os::active_processor_count() {
 
   // Starting with Windows 11 and Windows Server 2022 the OS has changed to
   // make processes and their threads span all processors in the system,
-  // across all processor groups, by default. Therefore, this function needs
-  // to detect Windows 11 or Windows Server 2022. See
+  // across all processor groups, by default. Therefore, on these operating
+  // systems, the full processor count can be used (since there are no processor
+  // affinity restritions at this point). Note that older operating systems can
+  // correctly report processor count but will not schedule threads across
+  // processor groups unless the application explicitly uses group affinity APIs
+  // to assign threads to processor groups. On these older operating systems, we
+  // will continue to use the dwNumberOfProcessors field. For details on the
+  // latest Windows scheduling behavior, see
   // https://learn.microsoft.com/en-us/windows/win32/procthread/processor-groups#behavior-starting-with-windows-11-and-windows-server-2022
   if (win32::is_windows_11_or_greater() || win32::is_windows_server_2022_or_greater()) {
     logical_processors = processor_count();

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -4064,7 +4064,7 @@ DWORD os::win32::active_processors_in_job_object() {
   return processors;
 }
 
-DWORD os::win32::get_available_logical_processors() {
+DWORD os::win32::available_logical_processors() {
   DWORD processors_in_job_object = active_processors_in_job_object();
 
   if (processors_in_job_object > 0) {
@@ -4095,13 +4095,13 @@ DWORD os::win32::get_available_logical_processors() {
   // to detect Windows 11 or Windows Server 2022. See
   // https://learn.microsoft.com/en-us/windows/win32/procthread/processor-groups#behavior-starting-with-windows-11-and-windows-server-2022
   if (is_windows_11_or_greater() || is_windows_server_2022_or_greater()) {
-    logical_processors = get_logical_processor_count();
+    logical_processors = system_logical_processor_count();
   }
 
   return logical_processors == 0 ? si.dwNumberOfProcessors : logical_processors;
 }
 
-DWORD os::win32::get_logical_processor_count() {
+DWORD os::win32::system_logical_processor_count() {
   DWORD logicalProcessors = 0;
   typedef BOOL(WINAPI* LPFN_GET_LOGICAL_PROCESSOR_INFORMATION_EX)(
       LOGICAL_PROCESSOR_RELATIONSHIP, PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX, PDWORD);
@@ -4160,7 +4160,7 @@ void os::win32::initialize_system_info() {
   _processor_type  = si.dwProcessorType;
   _processor_level = si.wProcessorLevel;
 
-  DWORD logicalProcessors = get_available_logical_processors();
+  DWORD logicalProcessors = available_logical_processors();
   set_processor_count(logicalProcessors > 0 ? logicalProcessors : si.dwNumberOfProcessors);
 
   MEMORYSTATUSEX ms;

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -4057,7 +4057,7 @@ bool os::win32::schedules_all_processor_groups() {
   // to detect Windows 11 or Windows Server 2022. See
   // https://learn.microsoft.com/en-us/windows/win32/procthread/processor-groups#behavior-starting-with-windows-11-and-windows-server-2022
 
-  if (IsWindows10OrGreater()) {
+  if (_major_version >= 10) {
     if (IsWindowsServer()) {
       // Windows Server 2022 starts at build 20348.169 as per
       // https://learn.microsoft.com/en-us/windows/release-health/release-information

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -4053,7 +4053,7 @@ bool os::win32::is_windows_server_2022_or_greater() {
 
 DWORD os::win32::active_processors_in_job_object() {
   BOOL is_in_job_object = false;
-  if (!IsProcessInJob(GetCurrentProcess(), NULL, &is_in_job_object)) {
+  if (!IsProcessInJob(GetCurrentProcess(), nullptr, &is_in_job_object)) {
     warning("IsProcessInJob() failed: GetLastError->%ld.", GetLastError());
     return 0;
   }
@@ -4064,17 +4064,17 @@ DWORD os::win32::active_processors_in_job_object() {
 
   DWORD processors = 0;
 
-  LPVOID job_object_information = NULL;
+  LPVOID job_object_information = nullptr;
   DWORD job_object_information_length = 0;
 
-  if (!QueryInformationJobObject(NULL, JobObjectGroupInformationEx, NULL, 0, &job_object_information_length)) {
+  if (!QueryInformationJobObject(nullptr, JobObjectGroupInformationEx, nullptr, 0, &job_object_information_length)) {
     DWORD last_error = GetLastError();
     if (last_error == ERROR_INSUFFICIENT_BUFFER) {
       DWORD group_count = job_object_information_length / sizeof(GROUP_AFFINITY);
 
       job_object_information = os::malloc(job_object_information_length, mtInternal);
-      if (job_object_information != NULL) {
-          if (QueryInformationJobObject(NULL, JobObjectGroupInformationEx, job_object_information, job_object_information_length, &job_object_information_length)) {
+      if (job_object_information != nullptr) {
+          if (QueryInformationJobObject(nullptr, JobObjectGroupInformationEx, job_object_information, job_object_information_length, &job_object_information_length)) {
             assert(group_count == job_object_information_length / sizeof(GROUP_AFFINITY), "Unexpected group count");
 
             for (DWORD i = 0; i < group_count; i++) {
@@ -4108,9 +4108,9 @@ DWORD os::win32::system_logical_processor_count() {
       GetModuleHandle(TEXT("kernel32")),
       "GetLogicalProcessorInformationEx");
 
-  if (glpiex != NULL) {
+  if (glpiex != nullptr) {
     LOGICAL_PROCESSOR_RELATIONSHIP relationship_type = RelationGroup;
-    PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX system_logical_processor_info = NULL;
+    PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX system_logical_processor_info = nullptr;
     DWORD returned_length = 0;
 
     // https://learn.microsoft.com/en-us/windows/win32/api/sysinfoapi/nf-sysinfoapi-getlogicalprocessorinformationex
@@ -4120,7 +4120,7 @@ DWORD os::win32::system_logical_processor_count() {
       if (last_error == ERROR_INSUFFICIENT_BUFFER) {
         system_logical_processor_info = (PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX)os::malloc(returned_length, mtInternal);
 
-        if (NULL == system_logical_processor_info) {
+        if (nullptr == system_logical_processor_info) {
           warning("os::malloc() failed to allocate %ld bytes for GetLogicalProcessorInformationEx buffer", returned_length);
         } else if (!glpiex(relationship_type, system_logical_processor_info, &returned_length)) {
           warning("GetLogicalProcessorInformationEx() failed: GetLastError->%ld.", GetLastError());

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -4060,6 +4060,12 @@ int os::win32::bit_count(ULONG64 argument) {
 }
 
 DWORD os::win32::active_processors_in_job_object() {
+  BOOL is_in_job_object = false;
+  if (!IsProcessInJob(GetCurrentProcess(), NULL, &is_in_job_object)) {
+    warning("IsProcessInJob() failed: GetLastError->%ld.", GetLastError());
+    return 0;
+  }
+
   DWORD processors = 0;
 
   LPVOID job_object_information = NULL;

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -3990,7 +3990,7 @@ int    os::win32::_build_minor               = 0;
 
 void os::win32::initialize_windows_version() {
   if (_major_version > 0) {
-    return; // nothing to do if already the version has already been set
+    return; // nothing to do if the version has already been set
   }
 
   VS_FIXEDFILEINFO *file_info;

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -4066,6 +4066,10 @@ DWORD os::win32::active_processors_in_job_object() {
     return 0;
   }
 
+  if (!is_in_job_object) {
+    return 0;
+  }
+
   DWORD processors = 0;
 
   LPVOID job_object_information = NULL;

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -1891,6 +1891,12 @@ void os::pd_print_cpu_info(outputStream* st, char* buf, size_t buflen) {
   if (proc_count < 1) {
     SYSTEM_INFO si;
     GetSystemInfo(&si);
+
+    // This is the number of logical processors in the current processor group only and is therefore
+    // at most 64. The GetLogicalProcessorInformation function is used to compute the total number
+    // of processors. However, it requires memory to be allocated for the processor information buffer.
+    // Since this method is used in paths where memory allocation should not be done (i.e. after a crash),
+    // only the number of processors in the current group will be returned.
     proc_count = si.dwNumberOfProcessors;
   }
 
@@ -3977,8 +3983,7 @@ void os::win32::initialize_windows_version() {
   DWORD version_size = 0;
 
   // Get the full path to \Windows\System32\kernel32.dll and use that for
-  // determining what version of Windows we're running on. This is the same
-  // approach used in src/java.base/windows/native/libjava/java_props_md.c
+  // determining what version of Windows we're running on.
   UINT buffer_size = GetSystemDirectoryW(NULL, 0);
   if (buffer_size == 0) {
     warning("GetSystemDirectoryW() failed: GetLastError->%ld.", GetLastError());

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -4075,7 +4075,7 @@ DWORD os::win32::active_processors_in_job_object() {
       job_object_information = os::malloc(job_object_information_length, mtInternal);
       if (job_object_information != NULL) {
           if (QueryInformationJobObject(NULL, JobObjectGroupInformationEx, job_object_information, job_object_information_length, &job_object_information_length)) {
-            assert(group_count == job_object_information_length / sizeof(GROUP_AFFINITY));
+            assert(group_count == job_object_information_length / sizeof(GROUP_AFFINITY), "Unexpected group count");
 
             for (DWORD i = 0; i < group_count; i++) {
               KAFFINITY group_affinity = ((GROUP_AFFINITY*)job_object_information)[i].Mask;

--- a/src/hotspot/os/windows/os_windows.hpp
+++ b/src/hotspot/os/windows/os_windows.hpp
@@ -44,6 +44,10 @@ class os::win32 {
   static bool   _is_windows_server;
   static bool   _has_exit_bug;
 
+  static int    _major_version;
+  static int    _minor_version;
+  static int    _build_number;
+
   static void print_windows_version(outputStream* st);
   static void print_uptime_info(outputStream* st);
 
@@ -56,6 +60,8 @@ class os::win32 {
   // Windows-specific interface:
   static void   initialize_system_info();
   static void   setmode_streams();
+  static void   compute_windows_version();
+  static bool   schedules_all_processor_groups();
 
   // Processor info as provided by NT
   static int processor_type()  { return _processor_type;  }

--- a/src/hotspot/os/windows/os_windows.hpp
+++ b/src/hotspot/os/windows/os_windows.hpp
@@ -61,6 +61,8 @@ class os::win32 {
   static void   initialize_system_info();
   static void   setmode_streams();
   static void   compute_windows_version();
+  static bool   is_windows_11_or_greater();
+  static bool   is_windows_server_2022_or_greater();
   static bool   schedules_all_processor_groups();
   static DWORD  get_logical_processor_count();
 

--- a/src/hotspot/os/windows/os_windows.hpp
+++ b/src/hotspot/os/windows/os_windows.hpp
@@ -63,6 +63,8 @@ class os::win32 {
   static void   compute_windows_version();
   static bool   is_windows_11_or_greater();
   static bool   is_windows_server_2022_or_greater();
+  static int    count_set_bits(ULONG64 argument);
+  static DWORD  get_available_logical_processors();
   static DWORD  get_logical_processor_count();
 
   // Processor info as provided by NT

--- a/src/hotspot/os/windows/os_windows.hpp
+++ b/src/hotspot/os/windows/os_windows.hpp
@@ -62,6 +62,7 @@ class os::win32 {
   static void   setmode_streams();
   static void   compute_windows_version();
   static bool   schedules_all_processor_groups();
+  static DWORD  get_logical_processor_count();
 
   // Processor info as provided by NT
   static int processor_type()  { return _processor_type;  }

--- a/src/hotspot/os/windows/os_windows.hpp
+++ b/src/hotspot/os/windows/os_windows.hpp
@@ -63,7 +63,6 @@ class os::win32 {
   static void   compute_windows_version();
   static bool   is_windows_11_or_greater();
   static bool   is_windows_server_2022_or_greater();
-  static bool   schedules_all_processor_groups();
   static DWORD  get_logical_processor_count();
 
   // Processor info as provided by NT

--- a/src/hotspot/os/windows/os_windows.hpp
+++ b/src/hotspot/os/windows/os_windows.hpp
@@ -47,6 +47,7 @@ class os::win32 {
   static int    _major_version;
   static int    _minor_version;
   static int    _build_number;
+  static int    _build_minor;
 
   static void print_windows_version(outputStream* st);
   static void print_uptime_info(outputStream* st);
@@ -66,6 +67,22 @@ class os::win32 {
   static int    count_set_bits(ULONG64 argument);
   static DWORD  get_available_logical_processors();
   static DWORD  get_logical_processor_count();
+  static int windows_major_version() {
+    compute_windows_version();
+    return _major_version;
+  }
+  static int windows_minor_version() {
+    compute_windows_version();
+    return _minor_version;
+  }
+  static int windows_build_number() {
+    compute_windows_version();
+    return _build_number;
+  }
+  static int windows_build_minor() {
+    compute_windows_version();
+    return _build_minor;
+  }
 
   // Processor info as provided by NT
   static int processor_type()  { return _processor_type;  }

--- a/src/hotspot/os/windows/os_windows.hpp
+++ b/src/hotspot/os/windows/os_windows.hpp
@@ -99,6 +99,7 @@ class os::win32 {
   static void initialize_performance_counter();
   static void compute_windows_version();
   static int  count_set_bits(ULONG64 argument);
+  static DWORD active_processors_in_job_object();
 
  public:
   // Generic interface:

--- a/src/hotspot/os/windows/os_windows.hpp
+++ b/src/hotspot/os/windows/os_windows.hpp
@@ -63,8 +63,8 @@ class os::win32 {
   static void   setmode_streams();
   static bool   is_windows_11_or_greater();
   static bool   is_windows_server_2022_or_greater();
-  static DWORD  get_available_logical_processors();
-  static DWORD  get_logical_processor_count();
+  static DWORD  available_logical_processors();
+  static DWORD  system_logical_processor_count();
   static int windows_major_version() {
     compute_windows_version();
     return _major_version;

--- a/src/hotspot/os/windows/os_windows.hpp
+++ b/src/hotspot/os/windows/os_windows.hpp
@@ -65,19 +65,19 @@ class os::win32 {
   static bool   is_windows_server_2022_or_greater();
   static DWORD  system_logical_processor_count();
   static int windows_major_version() {
-    compute_windows_version();
+    initialize_windows_version();
     return _major_version;
   }
   static int windows_minor_version() {
-    compute_windows_version();
+    initialize_windows_version();
     return _minor_version;
   }
   static int windows_build_number() {
-    compute_windows_version();
+    initialize_windows_version();
     return _build_number;
   }
   static int windows_build_minor() {
-    compute_windows_version();
+    initialize_windows_version();
     return _build_minor;
   }
 
@@ -96,8 +96,8 @@ class os::win32 {
  private:
 
   static void initialize_performance_counter();
-  static void compute_windows_version();
-  static int  count_set_bits(ULONG64 argument);
+  static void initialize_windows_version();
+  static int  bit_count(ULONG64 argument);
   static DWORD active_processors_in_job_object();
 
  public:

--- a/src/hotspot/os/windows/os_windows.hpp
+++ b/src/hotspot/os/windows/os_windows.hpp
@@ -61,10 +61,8 @@ class os::win32 {
   // Windows-specific interface:
   static void   initialize_system_info();
   static void   setmode_streams();
-  static void   compute_windows_version();
   static bool   is_windows_11_or_greater();
   static bool   is_windows_server_2022_or_greater();
-  static int    count_set_bits(ULONG64 argument);
   static DWORD  get_available_logical_processors();
   static DWORD  get_logical_processor_count();
   static int windows_major_version() {
@@ -99,6 +97,8 @@ class os::win32 {
  private:
 
   static void initialize_performance_counter();
+  static void compute_windows_version();
+  static int  count_set_bits(ULONG64 argument);
 
  public:
   // Generic interface:

--- a/src/hotspot/os/windows/os_windows.hpp
+++ b/src/hotspot/os/windows/os_windows.hpp
@@ -63,7 +63,6 @@ class os::win32 {
   static void   setmode_streams();
   static bool   is_windows_11_or_greater();
   static bool   is_windows_server_2022_or_greater();
-  static DWORD  available_logical_processors();
   static DWORD  system_logical_processor_count();
   static int windows_major_version() {
     compute_windows_version();

--- a/src/hotspot/os/windows/os_windows.hpp
+++ b/src/hotspot/os/windows/os_windows.hpp
@@ -97,7 +97,6 @@ class os::win32 {
 
   static void initialize_performance_counter();
   static void initialize_windows_version();
-  static int  bit_count(ULONG64 argument);
   static DWORD active_processors_in_job_object();
 
  public:

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -247,6 +247,9 @@ const int ObjectAlignmentInBytes = 8;
           "page size for the environment as the maximum)")                  \
           range(0, max_uintx)                                               \
                                                                             \
+  product(bool, EnableAllLargePageSizes, false, EXPERIMENTAL,               \
+          "Using high time resolution (for Windows 11+ and Win64 only)")    \
+                                                                            \
   product(size_t, LargePageHeapSizeThreshold, 128*M,                        \
           "Use large pages if maximum heap is at least this big")           \
           range(0, max_uintx)                                               \

--- a/test/hotspot/gtest/runtime/test_os_windows.cpp
+++ b/test/hotspot/gtest/runtime/test_os_windows.cpp
@@ -703,6 +703,22 @@ TEST_VM(os_windows, reserve_memory_special) {
   TestReserveMemorySpecial_test();
 }
 
+TEST_VM(os_windows, processor_count) {
+  int processors = os::processor_count();
+  EXPECT_GT(processors, 0) << "Expected at least 1 processor";
+
+  int active_processors = os::active_processor_count();
+  EXPECT_GT(active_processors, 0) << "Expected at least 1 active processor";
+
+  bool schedules_all_processor_groups = os::win32::is_windows_11_or_greater() || os::win32::is_windows_server_2022_or_greater();
+  if (schedules_all_processor_groups) {
+    EXPECT_EQ(active_processors, processors) << "Expected all processors to be active";
+  } else {
+    // active_processors should be at most the number of processors in 1 Windows processor group.
+    EXPECT_LE(active_processors, processors) << "Expected active processors to not exceed available processors";
+  }
+}
+
 class ReserveMemorySpecialRunnable : public TestRunnable {
 public:
   void runUnitTest() const {

--- a/test/hotspot/gtest/runtime/test_os_windows.cpp
+++ b/test/hotspot/gtest/runtime/test_os_windows.cpp
@@ -703,6 +703,56 @@ TEST_VM(os_windows, reserve_memory_special) {
   TestReserveMemorySpecial_test();
 }
 
+TEST_VM(os_windows, large_page_init_decide_size) {
+    // Initial setup
+    UseLargePages = true;
+    bool schedules_all_processor_groups = true;
+    size_t LargePageSizeInBytes = 0; // Reset to default
+
+    // Test for large page support
+    size_t decided_size = os::large_page_init_decide_size();
+    size_t min_size = os::GetLargePageMinimum();
+    if (min_size == 0) {
+        EXPECT_EQ(decided_size, 0) << "Expected decided size to be 0 when large page is not supported by the processor";
+    }
+
+    // Scenario 1: Test with 2MB large page size
+    LargePageSizeInBytes = 2 * M; // Set large page size to 2MB
+    decided_size = os::large_page_init_decide_size(); // Recalculate decided size
+    if (min_size == 2 * M) {
+        EXPECT_EQ(decided_size, 2 * M) << "Expected decided size to be 2M when large page and OS reported size are both 2M";
+    }
+
+    // Scenario 2: Test with 1MB large page size
+    LargePageSizeInBytes = 1 * M; // Set large page size to 1MB
+    decided_size = os::large_page_init_decide_size(); // Recalculate decided size
+    if (min_size == 2 * M) {
+        EXPECT_EQ(decided_size, 2 * M) << "Expected decided size to be 2M when large page is 1M and OS reported size is 2M";
+    }
+
+    // Check for specific OS versions or architectures
+    schedules_all_processor_groups = false; // Reset the flag for additional checks
+    if (schedules_all_processor_groups) {
+        // Add specific checks for OS version 11 or greater
+    }
+    else {
+#if defined(IA32) || defined(AMD64)
+        if (!os::EnableAllLargePageSizes && (min_size > 4 * M || LargePageSizeInBytes > 4 * M)) {
+            EXPECT_EQ(decided_size, 0) << "Expected decided size to be 0 for large pages bigger than 4mb on IA32 or AMD64";
+        }
+#endif
+    }
+
+    // Additional check for non-multiple of minimum size
+    LargePageSizeInBytes = 5 * M; // Set an arbitrary large page size
+    decided_size = os::large_page_init_decide_size(); // Recalculate decided size
+    if (LargePageSizeInBytes > 0 && LargePageSizeInBytes % min_size != 0) {
+        EXPECT_EQ(decided_size, min_size) << "Expected decided size to default to minimum page size when LargePageSizeInBytes is not a multiple of minimum size";
+    }
+}
+
+
+
 TEST_VM(os_windows, processor_count) {
   int processors = os::processor_count();
   EXPECT_GT(processors, 0) << "Expected at least 1 processor";


### PR DESCRIPTION
This pull request introduces enhancements to the handling of large page sizes in the Microsoft OpenJDK for Windows systems, aiming to align its capabilities with those observed on Linux platforms. Investigation through SPECJBB benchmarks across various platforms revealed a 16-year-old limitation in handling large pages over 4MB for IA32/AMD64 architectures, with no such constraints for Windows on ARM64.

The goal of this change is to overcome the 4MB large page size limitation, thereby enhancing Windows' large page support to match Linux's more flexible handling capabilities. This decision was influenced by issues observed with code cache and large page utilization, alongside insights from Linux's implementation strategies. The implementation supports multiple large page sizes on recent versions of Windows (Windows Client version >=11 and Windows Server version >=22), specifically excluding the IA32 architecture.

Key changes and bug fixes include enabling Linux support for multiple huge page sizes with `-XX:LargePageSizeInBytes`, adapting similar logic for Windows support, and utilizing logic from JDK-8271195 to use the largest available large page size smaller than `LargePageSizeInBytes` when available. This approach is further supported by addressing several JDK bug reports and enhancement requests related to large page handling, ensuring a comprehensive update to large page management.

This update removes the 4MB limit on AMD64 for Windows 11+ and Server 22+, populating the shared array to enable fallback options on all architectures except IA32. The implementation introduces an experimental flag, defaulting to FALSE, to facilitate testing and gradual adoption of these changes. The flag allows users to opt-in to the new large page handling logic, with a warning mechanism implemented for cases where the requested large page size is not a multiple of the OS minimum page size.