### PR TITLE
Use GetTempPath2 API instead of GetTempPath

### DIFF
--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -1019,6 +1019,10 @@ typedef HRESULT (WINAPI *GetThreadDescriptionFnPtr)(HANDLE, PWSTR*);
 static SetThreadDescriptionFnPtr _SetThreadDescription = nullptr;
 DEBUG_ONLY(static GetThreadDescriptionFnPtr _GetThreadDescription = nullptr;)
 
+// For dynamic lookup of GetTempPath2 API
+typedef DWORD (WINAPI *GetTempPath2AFnPtr)(DWORD, LPSTR);
+static GetTempPath2AFnPtr _GetTempPath2A = nullptr;
+
 // forward decl.
 static errno_t convert_to_unicode(char const* char_path, LPWSTR* unicode_path);
 
@@ -1515,12 +1519,16 @@ int os::closedir(DIR *dirp) {
 // directory not the java application's temp directory, ala java.io.tmpdir.
 const char* os::get_temp_directory() {
   static char path_buf[MAX_PATH];
-  if (GetTempPath(MAX_PATH, path_buf) > 0) {
+  if (_GetTempPath2A != nullptr) {
+    if (_GetTempPath2A(MAX_PATH, path_buf) > 0) {
     return path_buf;
-  } else {
-    path_buf[0] = '\0';
+    }
+  }
+  else if (GetTempPath(MAX_PATH, path_buf) > 0) {
     return path_buf;
   }
+  path_buf[0] = '\0';
+  return path_buf;
 }
 
 // Needs to be in os specific directory because windows requires another

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -1523,8 +1523,7 @@ const char* os::get_temp_directory() {
     if (_GetTempPath2A(MAX_PATH, path_buf) > 0) {
     return path_buf;
     }
-  }
-  else if (GetTempPath(MAX_PATH, path_buf) > 0) {
+  } else if (GetTempPath(MAX_PATH, path_buf) > 0) {
     return path_buf;
   }
   path_buf[0] = '\0';
@@ -4719,6 +4718,14 @@ jint os::init_2(void) {
   }
   log_info(os, thread)("The SetThreadDescription API is%s available.", _SetThreadDescription == nullptr ? " not" : "");
 
+  // Lookup GetTempPath2
+  if (_kernelbase != nullptr) {
+    _GetTempPath2A =
+      reinterpret_cast<GetTempPath2AFnPtr>(
+                                         GetProcAddress(_kernelbase,
+                                                        "GetTempPath2A"));
+  }
+  log_info(os, thread)("The _GetTempPath2A API is%s available.", _GetTempPath2A == nullptr ? " not" : "");
 
   return JNI_OK;
 }


### PR DESCRIPTION
https://bugs.openjdk.org/browse/JDK-8337408

Use the `GetTempPath2` APIs instead of the `GetTempPath` APIs in native code across the OpenJDK repository to retrieve the temporary directory path, as `GetTempPath2` provides enhanced security. While `GetTempPath` may still function without errors, using `GetTempPath2` reduces the risk of potential exploits for users.

The code is duplicated, and we cannot address this issue for the following reasons:
1. The changes are in four different folders, and there is no shared code between the folders: java.base, jdk.package, jdk.attach, and hotspot.
2. Some parts of the code use version A, while others use version W (ANSI vs. Unicode).