### PR TITLE
8350152: Reverse location of young and tenured generations

### DIFF
--- a/src/hotspot/share/gc/serial/defNewGeneration.cpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.cpp
@@ -140,16 +140,12 @@ class CLDScanClosure: public CLDClosure {
 };
 
 class IsAliveClosure: public BoolObjectClosure {
-  DefNewGeneration* _young_gen;
+  HeapWord*         _young_gen_end;
 public:
-  IsAliveClosure(DefNewGeneration* g):
-    _young_gen(g) {}
+  IsAliveClosure(DefNewGeneration* g): _young_gen_end(g->reserved().end()) {}
 
   bool do_object_b(oop p) {
-    HeapWord* heap_word_ptr = cast_from_oop<HeapWord*>(p);
-    bool is_in_young_gen = _young_gen->is_in_reserved((void*)heap_word_ptr);
-
-    return (!is_in_young_gen) || p->is_forwarded();
+    return cast_from_oop<HeapWord*>(p) >= _young_gen_end || p->is_forwarded();
   }
 };
 
@@ -176,10 +172,11 @@ class AdjustWeakRootClosure: public OffHeapScanClosure {
 
 class KeepAliveClosure: public OopClosure {
   DefNewGeneration* _young_gen;
+  HeapWord*         _young_gen_end;
   CardTableRS* _rs;
 
   bool is_in_young_gen(void* p) const {
-    return _young_gen->is_in_reserved(p);
+    return p < _young_gen_end;
   }
 
   template <class T>
@@ -199,6 +196,7 @@ class KeepAliveClosure: public OopClosure {
 public:
   KeepAliveClosure(DefNewGeneration* g) :
     _young_gen(g),
+    _young_gen_end(g->reserved().end()),
     _rs(SerialHeap::heap()->rem_set()) {}
 
   void do_oop(oop* p)       { do_oop_work(p); }

--- a/src/hotspot/share/gc/serial/defNewGeneration.cpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.cpp
@@ -140,12 +140,12 @@ class CLDScanClosure: public CLDClosure {
 };
 
 class IsAliveClosure: public BoolObjectClosure {
-  HeapWord*         _old_gen_boundary;
+  HeapWord*         _gen_boundary;
 public:
-  IsAliveClosure(DefNewGeneration* g): _old_gen_boundary(g->old_gen_boundary()) {}
+  IsAliveClosure(DefNewGeneration* g): _gen_boundary(g->gen_boundary()) {}
 
   bool do_object_b(oop p) {
-    bool is_in_lower_region = cast_from_oop<HeapWord*>(p) < _old_gen_boundary;
+    bool is_in_lower_region = cast_from_oop<HeapWord*>(p) < _gen_boundary;
     bool is_in_young_gen = SwapSerialGCGenerations ^ is_in_lower_region;
     return !is_in_young_gen || p->is_forwarded();
   }
@@ -174,11 +174,11 @@ class AdjustWeakRootClosure: public OffHeapScanClosure {
 
 class KeepAliveClosure: public OopClosure {
   DefNewGeneration* _young_gen;
-  HeapWord*         _old_gen_boundary;
+  HeapWord*         _gen_boundary;
   CardTableRS* _rs;
 
   bool is_in_young_gen(void* p) const {
-    bool is_in_lower_region = p < _old_gen_boundary;
+    bool is_in_lower_region = p < _gen_boundary;
     return SwapSerialGCGenerations ^ is_in_lower_region;
   }
 
@@ -199,7 +199,7 @@ class KeepAliveClosure: public OopClosure {
 public:
   KeepAliveClosure(DefNewGeneration* g) :
     _young_gen(g),
-    _old_gen_boundary(g->old_gen_boundary()),
+    _gen_boundary(g->gen_boundary()),
     _rs(SerialHeap::heap()->rem_set()) {}
 
   void do_oop(oop* p)       { do_oop_work(p); }
@@ -241,7 +241,7 @@ DefNewGeneration::DefNewGeneration(ReservedSpace rs,
   _eden_space = new ContiguousSpace();
   _from_space = new ContiguousSpace();
   _to_space   = new ContiguousSpace();
-  _old_gen_boundary = SwapSerialGCGenerations ? _reserved.start() : _reserved.end();
+  _gen_boundary = SwapSerialGCGenerations ? _reserved.start() : _reserved.end();
 
   // Compute the maximum eden and survivor space sizes. These sizes
   // are computed assuming the entire reserved space is committed.

--- a/src/hotspot/share/gc/serial/defNewGeneration.cpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.cpp
@@ -241,7 +241,7 @@ DefNewGeneration::DefNewGeneration(ReservedSpace rs,
   _eden_space = new ContiguousSpace();
   _from_space = new ContiguousSpace();
   _to_space   = new ContiguousSpace();
-  _old_gen_boundary = _reserved.end();
+  _old_gen_boundary = SwapSerialGCGenerations ? _reserved.start() : _reserved.end();
 
   // Compute the maximum eden and survivor space sizes. These sizes
   // are computed assuming the entire reserved space is committed.

--- a/src/hotspot/share/gc/serial/defNewGeneration.cpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.cpp
@@ -140,12 +140,14 @@ class CLDScanClosure: public CLDClosure {
 };
 
 class IsAliveClosure: public BoolObjectClosure {
-  HeapWord*         _young_gen_end;
+  HeapWord*         _old_gen_boundary;
 public:
-  IsAliveClosure(DefNewGeneration* g): _young_gen_end(g->reserved().end()) {}
+  IsAliveClosure(DefNewGeneration* g): _old_gen_boundary(g->old_gen_boundary()) {}
 
   bool do_object_b(oop p) {
-    return cast_from_oop<HeapWord*>(p) >= _young_gen_end || p->is_forwarded();
+    bool is_in_lower_region = cast_from_oop<HeapWord*>(p) < _old_gen_boundary;
+    bool is_in_young_gen = SwapSerialGCGenerations ^ is_in_lower_region;
+    return !is_in_young_gen || p->is_forwarded();
   }
 };
 
@@ -172,11 +174,12 @@ class AdjustWeakRootClosure: public OffHeapScanClosure {
 
 class KeepAliveClosure: public OopClosure {
   DefNewGeneration* _young_gen;
-  HeapWord*         _young_gen_end;
+  HeapWord*         _old_gen_boundary;
   CardTableRS* _rs;
 
   bool is_in_young_gen(void* p) const {
-    return p < _young_gen_end;
+    bool is_in_lower_region = p < _old_gen_boundary;
+    return SwapSerialGCGenerations ^ is_in_lower_region;
   }
 
   template <class T>
@@ -196,7 +199,7 @@ class KeepAliveClosure: public OopClosure {
 public:
   KeepAliveClosure(DefNewGeneration* g) :
     _young_gen(g),
-    _young_gen_end(g->reserved().end()),
+    _old_gen_boundary(g->old_gen_boundary()),
     _rs(SerialHeap::heap()->rem_set()) {}
 
   void do_oop(oop* p)       { do_oop_work(p); }
@@ -238,6 +241,7 @@ DefNewGeneration::DefNewGeneration(ReservedSpace rs,
   _eden_space = new ContiguousSpace();
   _from_space = new ContiguousSpace();
   _to_space   = new ContiguousSpace();
+  _old_gen_boundary = _reserved.end();
 
   // Compute the maximum eden and survivor space sizes. These sizes
   // are computed assuming the entire reserved space is committed.

--- a/src/hotspot/share/gc/serial/defNewGeneration.hpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.hpp
@@ -119,6 +119,7 @@ class DefNewGeneration: public Generation {
   ContiguousSpace* _eden_space;
   ContiguousSpace* _from_space;
   ContiguousSpace* _to_space;
+  HeapWord* _old_gen_boundary;
 
   STWGCTimer* _gc_timer;
 
@@ -155,6 +156,7 @@ class DefNewGeneration: public Generation {
   size_t free() const;
   size_t max_capacity() const;
   size_t capacity_before_gc() const;
+  HeapWord* old_gen_boundary() const { return _old_gen_boundary; }
 
   // Returns "TRUE" iff "p" points into the used areas in each space of young-gen.
   bool is_in(const void* p) const;

--- a/src/hotspot/share/gc/serial/defNewGeneration.hpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.hpp
@@ -119,7 +119,7 @@ class DefNewGeneration: public Generation {
   ContiguousSpace* _eden_space;
   ContiguousSpace* _from_space;
   ContiguousSpace* _to_space;
-  HeapWord* _old_gen_boundary;
+  HeapWord* _gen_boundary;
 
   STWGCTimer* _gc_timer;
 
@@ -156,7 +156,7 @@ class DefNewGeneration: public Generation {
   size_t free() const;
   size_t max_capacity() const;
   size_t capacity_before_gc() const;
-  HeapWord* old_gen_boundary() const { return _old_gen_boundary; }
+  HeapWord* gen_boundary() const { return _gen_boundary; }
 
   // Returns "TRUE" iff "p" points into the used areas in each space of young-gen.
   bool is_in(const void* p) const;

--- a/src/hotspot/share/gc/serial/serialHeap.cpp
+++ b/src/hotspot/share/gc/serial/serialHeap.cpp
@@ -187,18 +187,25 @@ jint SerialHeap::initialize() {
 
   initialize_reserved_region(heap_rs);
 
-  ReservedSpace young_rs = heap_rs.first_part(MaxNewSize, GenAlignment);
-  ReservedSpace old_rs = heap_rs.last_part(MaxNewSize, GenAlignment);
-
   _rem_set = new CardTableRS(_reserved);
-  _rem_set->initialize(young_rs.base(), old_rs.base());
+
+  if (SwapGenerations) {
+    ReservedSpace old_rs = heap_rs.first_part(MaxOldSize, GenAlignment);
+    ReservedSpace young_rs = heap_rs.last_part(MaxOldSize, GenAlignment);
+    _rem_set->initialize(old_rs.base(), young_rs.base());
+    _young_gen = new DefNewGeneration(young_rs, NewSize, MinNewSize, MaxNewSize);
+    _old_gen = new TenuredGeneration(old_rs, OldSize, MinOldSize, MaxOldSize, rem_set());
+  } else {
+    ReservedSpace young_rs = heap_rs.first_part(MaxNewSize, GenAlignment);
+    ReservedSpace old_rs = heap_rs.last_part(MaxNewSize, GenAlignment);
+    _rem_set->initialize(young_rs.base(), old_rs.base());
+    _young_gen = new DefNewGeneration(young_rs, NewSize, MinNewSize, MaxNewSize);
+    _old_gen = new TenuredGeneration(old_rs, OldSize, MinOldSize, MaxOldSize, rem_set());
+  }
 
   CardTableBarrierSet *bs = new CardTableBarrierSet(_rem_set);
   bs->initialize();
   BarrierSet::set_barrier_set(bs);
-
-  _young_gen = new DefNewGeneration(young_rs, NewSize, MinNewSize, MaxNewSize);
-  _old_gen = new TenuredGeneration(old_rs, OldSize, MinOldSize, MaxOldSize, rem_set());
 
   GCInitLogger::print();
 
@@ -787,10 +794,7 @@ void SerialHeap::do_full_collection_no_gc_locker(bool clear_all_soft_refs) {
 }
 
 bool SerialHeap::is_in_young(const void* p) const {
-  bool result = p < _old_gen->reserved().start();
-  assert(result == _young_gen->is_in_reserved(p),
-         "incorrect test - result=%d, p=" PTR_FORMAT, result, p2i(p));
-  return result;
+  return _young_gen->is_in_reserved(p);
 }
 
 bool SerialHeap::requires_barriers(stackChunkOop obj) const {

--- a/src/hotspot/share/gc/serial/serialHeap.cpp
+++ b/src/hotspot/share/gc/serial/serialHeap.cpp
@@ -190,14 +190,17 @@ jint SerialHeap::initialize() {
   _rem_set = new CardTableRS(_reserved);
 
   if (SwapSerialGCGenerations) {
-    ReservedSpace old_rs = heap_rs.first_part(MaxOldSize, GenAlignment);
-    ReservedSpace young_rs = heap_rs.last_part(MaxOldSize, GenAlignment);
+    size_t split_offset = heap_rs.size() - MaxNewSize;
+    ReservedSpace old_rs = heap_rs.first_part(split_offset, GenAlignment);
+    ReservedSpace young_rs = heap_rs.last_part(split_offset, GenAlignment);
+
     _rem_set->initialize(old_rs.base(), young_rs.base());
     _young_gen = new DefNewGeneration(young_rs, NewSize, MinNewSize, MaxNewSize);
     _old_gen = new TenuredGeneration(old_rs, OldSize, MinOldSize, MaxOldSize, rem_set());
   } else {
     ReservedSpace young_rs = heap_rs.first_part(MaxNewSize, GenAlignment);
     ReservedSpace old_rs = heap_rs.last_part(MaxNewSize, GenAlignment);
+
     _rem_set->initialize(young_rs.base(), old_rs.base());
     _young_gen = new DefNewGeneration(young_rs, NewSize, MinNewSize, MaxNewSize);
     _old_gen = new TenuredGeneration(old_rs, OldSize, MinOldSize, MaxOldSize, rem_set());

--- a/src/hotspot/share/gc/serial/serialHeap.cpp
+++ b/src/hotspot/share/gc/serial/serialHeap.cpp
@@ -192,12 +192,16 @@ jint SerialHeap::initialize() {
   if (SwapSerialGCGenerations) {
     ReservedSpace old_rs = heap_rs.first_part(MaxOldSize, GenAlignment);
     ReservedSpace young_rs = heap_rs.last_part(MaxOldSize, GenAlignment);
+    _old_gen_boundary = young_rs.base();
+
     _rem_set->initialize(old_rs.base(), young_rs.base());
     _young_gen = new DefNewGeneration(young_rs, NewSize, MinNewSize, MaxNewSize);
     _old_gen = new TenuredGeneration(old_rs, OldSize, MinOldSize, MaxOldSize, rem_set());
   } else {
     ReservedSpace young_rs = heap_rs.first_part(MaxNewSize, GenAlignment);
     ReservedSpace old_rs = heap_rs.last_part(MaxNewSize, GenAlignment);
+    _old_gen_boundary = old_rs.base();
+
     _rem_set->initialize(young_rs.base(), old_rs.base());
     _young_gen = new DefNewGeneration(young_rs, NewSize, MinNewSize, MaxNewSize);
     _old_gen = new TenuredGeneration(old_rs, OldSize, MinOldSize, MaxOldSize, rem_set());
@@ -794,7 +798,9 @@ void SerialHeap::do_full_collection_no_gc_locker(bool clear_all_soft_refs) {
 }
 
 bool SerialHeap::is_in_young(const void* p) const {
-  bool result = p < _old_gen->reserved().start();
+  bool is_in_lower_region = p < _old_gen_boundary;
+  bool result = SwapSerialGCGenerations ^ is_in_lower_region;
+
   assert(result == _young_gen->is_in_reserved(p),
          "incorrect test - result=%d, p=" PTR_FORMAT, result, p2i(p));
   return result;

--- a/src/hotspot/share/gc/serial/serialHeap.cpp
+++ b/src/hotspot/share/gc/serial/serialHeap.cpp
@@ -190,17 +190,14 @@ jint SerialHeap::initialize() {
   _rem_set = new CardTableRS(_reserved);
 
   if (SwapSerialGCGenerations) {
-    size_t split_offset = heap_rs.size() - MaxNewSize;
-    ReservedSpace old_rs = heap_rs.first_part(split_offset, GenAlignment);
-    ReservedSpace young_rs = heap_rs.last_part(split_offset, GenAlignment);
-
+    ReservedSpace old_rs = heap_rs.first_part(MaxOldSize, GenAlignment);
+    ReservedSpace young_rs = heap_rs.last_part(MaxOldSize, GenAlignment);
     _rem_set->initialize(old_rs.base(), young_rs.base());
     _young_gen = new DefNewGeneration(young_rs, NewSize, MinNewSize, MaxNewSize);
     _old_gen = new TenuredGeneration(old_rs, OldSize, MinOldSize, MaxOldSize, rem_set());
   } else {
     ReservedSpace young_rs = heap_rs.first_part(MaxNewSize, GenAlignment);
     ReservedSpace old_rs = heap_rs.last_part(MaxNewSize, GenAlignment);
-
     _rem_set->initialize(young_rs.base(), old_rs.base());
     _young_gen = new DefNewGeneration(young_rs, NewSize, MinNewSize, MaxNewSize);
     _old_gen = new TenuredGeneration(old_rs, OldSize, MinOldSize, MaxOldSize, rem_set());

--- a/src/hotspot/share/gc/serial/serialHeap.cpp
+++ b/src/hotspot/share/gc/serial/serialHeap.cpp
@@ -189,7 +189,7 @@ jint SerialHeap::initialize() {
 
   _rem_set = new CardTableRS(_reserved);
 
-  if (SwapGenerations) {
+  if (SwapSerialGCGenerations) {
     ReservedSpace old_rs = heap_rs.first_part(MaxOldSize, GenAlignment);
     ReservedSpace young_rs = heap_rs.last_part(MaxOldSize, GenAlignment);
     _rem_set->initialize(old_rs.base(), young_rs.base());

--- a/src/hotspot/share/gc/serial/serialHeap.cpp
+++ b/src/hotspot/share/gc/serial/serialHeap.cpp
@@ -192,7 +192,7 @@ jint SerialHeap::initialize() {
   if (SwapSerialGCGenerations) {
     ReservedSpace old_rs = heap_rs.first_part(MaxOldSize, GenAlignment);
     ReservedSpace young_rs = heap_rs.last_part(MaxOldSize, GenAlignment);
-    _old_gen_boundary = young_rs.base();
+    _gen_boundary = young_rs.base();
 
     _rem_set->initialize(old_rs.base(), young_rs.base());
     _young_gen = new DefNewGeneration(young_rs, NewSize, MinNewSize, MaxNewSize);
@@ -200,7 +200,7 @@ jint SerialHeap::initialize() {
   } else {
     ReservedSpace young_rs = heap_rs.first_part(MaxNewSize, GenAlignment);
     ReservedSpace old_rs = heap_rs.last_part(MaxNewSize, GenAlignment);
-    _old_gen_boundary = old_rs.base();
+    _gen_boundary = old_rs.base();
 
     _rem_set->initialize(young_rs.base(), old_rs.base());
     _young_gen = new DefNewGeneration(young_rs, NewSize, MinNewSize, MaxNewSize);
@@ -798,7 +798,7 @@ void SerialHeap::do_full_collection_no_gc_locker(bool clear_all_soft_refs) {
 }
 
 bool SerialHeap::is_in_young(const void* p) const {
-  bool is_in_lower_region = p < _old_gen_boundary;
+  bool is_in_lower_region = p < _gen_boundary;
   bool result = SwapSerialGCGenerations ^ is_in_lower_region;
 
   assert(result == _young_gen->is_in_reserved(p),

--- a/src/hotspot/share/gc/serial/serialHeap.cpp
+++ b/src/hotspot/share/gc/serial/serialHeap.cpp
@@ -794,7 +794,10 @@ void SerialHeap::do_full_collection_no_gc_locker(bool clear_all_soft_refs) {
 }
 
 bool SerialHeap::is_in_young(const void* p) const {
-  return _young_gen->is_in_reserved(p);
+  bool result = p < _old_gen->reserved().start();
+  assert(result == _young_gen->is_in_reserved(p),
+         "incorrect test - result=%d, p=" PTR_FORMAT, result, p2i(p));
+  return result;
 }
 
 bool SerialHeap::requires_barriers(stackChunkOop obj) const {

--- a/src/hotspot/share/gc/serial/serialHeap.hpp
+++ b/src/hotspot/share/gc/serial/serialHeap.hpp
@@ -79,7 +79,7 @@ private:
   TenuredGeneration* _old_gen;
   HeapWord* _young_gen_saved_top;
   HeapWord* _old_gen_saved_top;
-  char* _old_gen_boundary;
+  char* _gen_boundary;
 
   // The singleton CardTable Remembered Set.
   CardTableRS* _rem_set;
@@ -165,7 +165,7 @@ public:
   // Assumes the young gen address range is less than that of the old gen.
   bool is_in_young(const void* p) const;
 
-  char* old_gen_boundary() const { return _old_gen_boundary; }
+  char* gen_boundary() const { return _gen_boundary; }
 
   bool requires_barriers(stackChunkOop obj) const override;
 

--- a/src/hotspot/share/gc/serial/serialHeap.hpp
+++ b/src/hotspot/share/gc/serial/serialHeap.hpp
@@ -79,6 +79,7 @@ private:
   TenuredGeneration* _old_gen;
   HeapWord* _young_gen_saved_top;
   HeapWord* _old_gen_saved_top;
+  char* _old_gen_boundary;
 
   // The singleton CardTable Remembered Set.
   CardTableRS* _rem_set;
@@ -163,6 +164,8 @@ public:
   // Returns true if p points into the reserved space for the young generation.
   // Assumes the young gen address range is less than that of the old gen.
   bool is_in_young(const void* p) const;
+
+  char* old_gen_boundary() const { return _old_gen_boundary; }
 
   bool requires_barriers(stackChunkOop obj) const override;
 

--- a/src/hotspot/share/gc/serial/serialHeap.inline.hpp
+++ b/src/hotspot/share/gc/serial/serialHeap.inline.hpp
@@ -32,14 +32,12 @@
 
 class ScavengeHelper {
   DefNewGeneration* _young_gen;
-  HeapWord*         _young_gen_end;
 public:
   ScavengeHelper(DefNewGeneration* young_gen) :
-    _young_gen(young_gen),
-    _young_gen_end(young_gen->reserved().end()) {}
+    _young_gen(young_gen) {}
 
   bool is_in_young_gen(void* p) const {
-    return p < _young_gen_end;
+    return _young_gen->is_in_reserved(p);
   }
 
   template <typename T, typename Func>

--- a/src/hotspot/share/gc/serial/serialHeap.inline.hpp
+++ b/src/hotspot/share/gc/serial/serialHeap.inline.hpp
@@ -32,14 +32,15 @@
 
 class ScavengeHelper {
   DefNewGeneration* _young_gen;
-  HeapWord*         _young_gen_end;
+  HeapWord*         _old_gen_boundary;
 public:
   ScavengeHelper(DefNewGeneration* young_gen) :
     _young_gen(young_gen),
-    _young_gen_end(young_gen->reserved().end()) {}
+    _old_gen_boundary(young_gen->old_gen_boundary()) {}
 
   bool is_in_young_gen(void* p) const {
-    return p < _young_gen_end;
+    bool is_in_lower_region = p < _old_gen_boundary;
+    return SwapSerialGCGenerations ^ is_in_lower_region;
   }
 
   template <typename T, typename Func>

--- a/src/hotspot/share/gc/serial/serialHeap.inline.hpp
+++ b/src/hotspot/share/gc/serial/serialHeap.inline.hpp
@@ -32,14 +32,14 @@
 
 class ScavengeHelper {
   DefNewGeneration* _young_gen;
-  HeapWord*         _old_gen_boundary;
+  HeapWord*         _gen_boundary;
 public:
   ScavengeHelper(DefNewGeneration* young_gen) :
     _young_gen(young_gen),
-    _old_gen_boundary(young_gen->old_gen_boundary()) {}
+    _gen_boundary(young_gen->gen_boundary()) {}
 
   bool is_in_young_gen(void* p) const {
-    bool is_in_lower_region = p < _old_gen_boundary;
+    bool is_in_lower_region = p < _gen_boundary;
     return SwapSerialGCGenerations ^ is_in_lower_region;
   }
 

--- a/src/hotspot/share/gc/serial/serialHeap.inline.hpp
+++ b/src/hotspot/share/gc/serial/serialHeap.inline.hpp
@@ -32,12 +32,14 @@
 
 class ScavengeHelper {
   DefNewGeneration* _young_gen;
+  HeapWord*         _young_gen_end;
 public:
   ScavengeHelper(DefNewGeneration* young_gen) :
-    _young_gen(young_gen) {}
+    _young_gen(young_gen),
+    _young_gen_end(young_gen->reserved().end()) {}
 
   bool is_in_young_gen(void* p) const {
-    return _young_gen->is_in_reserved(p);
+    return p < _young_gen_end;
   }
 
   template <typename T, typename Func>

--- a/src/hotspot/share/gc/serial/serial_globals.hpp
+++ b/src/hotspot/share/gc/serial/serial_globals.hpp
@@ -35,6 +35,10 @@
           "When disabled, informs the GC to shrink the java heap directly"  \
           " to the target size at the next full GC rather than requiring"   \
           " smaller steps during multiple full GCs.")                       \
+                                                                            \
+  product(bool, SwapGenerations, false, EXPERIMENTAL,                       \
+          "When enabled, informs the GC to place the tenured region before" \
+          " the young region in memory.")                                   \
 
 // end of GC_SERIAL_FLAGS
 

--- a/src/hotspot/share/gc/serial/serial_globals.hpp
+++ b/src/hotspot/share/gc/serial/serial_globals.hpp
@@ -36,7 +36,7 @@
           " to the target size at the next full GC rather than requiring"   \
           " smaller steps during multiple full GCs.")                       \
                                                                             \
-  product(bool, SwapGenerations, false, EXPERIMENTAL,                       \
+  product(bool, SwapSerialGCGenerations, false, EXPERIMENTAL,               \
           "When enabled, informs the GC to place the tenured region before" \
           " the young region in memory.")                                   \
 

--- a/src/hotspot/share/gc/shared/cardTable.cpp
+++ b/src/hotspot/share/gc/shared/cardTable.cpp
@@ -208,6 +208,11 @@ void CardTable::dirty_MemRegion(MemRegion mr) {
 }
 
 void CardTable::clear_MemRegion(MemRegion mr) {
+  if (mr.word_size() == 0) {
+    // no clear operation necessary
+    return;
+  }
+
   // Be conservative: only clean cards entirely contained within the
   // region.
   CardValue* cur;

--- a/src/hotspot/share/gc/shared/cardTable.cpp
+++ b/src/hotspot/share/gc/shared/cardTable.cpp
@@ -208,8 +208,15 @@ void CardTable::dirty_MemRegion(MemRegion mr) {
 }
 
 void CardTable::clear_MemRegion(MemRegion mr) {
+  // The MemRegion mr can have a word size of 0. This occurs the first time
+  // a SerialGC full collection is performed, for example. In that case, the
+  // MemRegion corresponds to the previously used region in the tenured space.
+  // Since that is an empty region, mr.last() will fall outside the bounds
+  // of the heap if the tenured region is at the start of the whole heap.
+  // We can avoid that assertion failure since there are no words to be cleared
+  // for a region with a word size of 0.
   if (mr.word_size() == 0) {
-    // no clear operation necessary
+    // no need to call memset on a card table region of size 0 bytes
     return;
   }
 


### PR DESCRIPTION
The [AHS Draft JEP in JDK-8350152](https://bugs.openjdk.org/browse/JDK-8350152) proposes dynamically sizing the young generation using GC overhead and adding support for committing and uncommitting memory depending on global memory pressure. The current implementation of the serial collector reserves a single block of memory for the entire heap then splits it into two ReservedSpaces, one for the young generation and another for the tenured generation. See [SerialHeap::initialize()](https://github.com/openjdk/jdk/blob/65f79c145b7b1b32ed064a37ad4d2b6aca935a4c/src/hotspot/share/gc/serial/serialHeap.cpp#L190-L191) for details. Each of the generations then individually commits and uncommits memory.

One drawback of this approach is that with dynamic sizing of the generations, fixed limits of the reserved spaces for each generation will not be compatible with the newly computed sizes. A possible workaround is to reserve twice the maximum heap size to enable each generation to grow to dynamically computed sizes. However, there would now be two memory regions to manage when committing and uncommitting memory in response to global memory pressure. This is addressed by using a single reserved space and dynamically partitioning its committed memory into tenured and young regions. After a full collection, the young generation is empty, and it is therefore easier to resize all the heap regions without needing to move data around. Expansion and contraction of the committed heap memory is therefore straightforward when the young generation appears after the tenured generation in memory. This change adds an experimental product flag for swapping the order of the young and tenured generations in memory. A future PR will then extend this experimental behavior to the use of a single VirtualSpace for committing and uncommitting memory for the heap.

This change depends on https://github.com/microsoft/openjdk-jdk/pull/25