### PR TITLE
8351011: Serial GC: Use a single VirtualSpace for both young and tenured generations

### DIFF
--- a/src/hotspot/share/gc/serial/defNewGeneration.cpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.cpp
@@ -140,12 +140,12 @@ class CLDScanClosure: public CLDClosure {
 };
 
 class IsAliveClosure: public BoolObjectClosure {
-  HeapWord*         _old_gen_boundary;
+  HeapWord*         _gen_boundary;
 public:
-  IsAliveClosure(DefNewGeneration* g): _old_gen_boundary(g->old_gen_boundary()) {}
+  IsAliveClosure(DefNewGeneration* g): _gen_boundary(g->gen_boundary()) {}
 
   bool do_object_b(oop p) {
-    bool is_in_lower_region = cast_from_oop<HeapWord*>(p) < _old_gen_boundary;
+    bool is_in_lower_region = cast_from_oop<HeapWord*>(p) < _gen_boundary;
     bool is_in_young_gen = SwapSerialGCGenerations ^ is_in_lower_region;
     return !is_in_young_gen || p->is_forwarded();
   }
@@ -174,11 +174,11 @@ class AdjustWeakRootClosure: public OffHeapScanClosure {
 
 class KeepAliveClosure: public OopClosure {
   DefNewGeneration* _young_gen;
-  HeapWord*         _old_gen_boundary;
+  HeapWord*         _gen_boundary;
   CardTableRS* _rs;
 
   bool is_in_young_gen(void* p) const {
-    bool is_in_lower_region = p < _old_gen_boundary;
+    bool is_in_lower_region = p < _gen_boundary;
     return SwapSerialGCGenerations ^ is_in_lower_region;
   }
 
@@ -199,7 +199,7 @@ class KeepAliveClosure: public OopClosure {
 public:
   KeepAliveClosure(DefNewGeneration* g) :
     _young_gen(g),
-    _old_gen_boundary(g->old_gen_boundary()),
+    _gen_boundary(g->gen_boundary()),
     _rs(SerialHeap::heap()->rem_set()) {}
 
   void do_oop(oop* p)       { do_oop_work(p); }
@@ -250,7 +250,7 @@ DefNewGeneration::DefNewGeneration(ReservedSpace rs,
   _eden_space = new ContiguousSpace();
   _from_space = new ContiguousSpace();
   _to_space   = new ContiguousSpace();
-  _old_gen_boundary = _reserved.end();
+  _gen_boundary = SwapSerialGCGenerations ? _reserved.start() : _reserved.end();
 
   // Compute the maximum eden and survivor space sizes. These sizes
   // are computed assuming the entire reserved space is committed.

--- a/src/hotspot/share/gc/serial/defNewGeneration.cpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.cpp
@@ -59,7 +59,6 @@
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/stack.inline.hpp"
 
-// TODO: update closures to avoid the cost of a method call for is_in_young_gen logic
 class PromoteFailureClosure : public InHeapScanClosure {
   template <typename T>
   void do_oop_work(T* p) {

--- a/src/hotspot/share/gc/serial/defNewGeneration.cpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.cpp
@@ -59,6 +59,7 @@
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/stack.inline.hpp"
 
+// TODO: update closures to avoid the cost of a method call for is_in_young_gen logic
 class PromoteFailureClosure : public InHeapScanClosure {
   template <typename T>
   void do_oop_work(T* p) {
@@ -231,11 +232,20 @@ DefNewGeneration::DefNewGeneration(ReservedSpace rs,
     _promo_failure_drain_in_progress(false),
     _string_dedup_requests()
 {
-  MemRegion cmr((HeapWord*)_virtual_space.low(),
-                (HeapWord*)_virtual_space.high());
   SerialHeap* gch = SerialHeap::heap();
 
-  gch->rem_set()->resize_covered_region(cmr);
+  uintx size;
+  if (SharedSerialGCVirtualSpace) {
+    _committed = gch->shared_virtual_space()->young_region();
+    size = gch->shared_virtual_space()->max_new_size();
+  } else {
+    HeapWord* committed_low = (HeapWord*)_virtual_space.low();
+    HeapWord* committed_high = (HeapWord*)_virtual_space.high();
+    _committed = MemRegion(committed_low, committed_high);
+    size = _virtual_space.reserved_size();
+  }
+
+  gch->rem_set()->resize_covered_region(_committed);
 
   _eden_space = new ContiguousSpace();
   _from_space = new ContiguousSpace();
@@ -244,7 +254,6 @@ DefNewGeneration::DefNewGeneration(ReservedSpace rs,
   // Compute the maximum eden and survivor space sizes. These sizes
   // are computed assuming the entire reserved space is committed.
   // These values are exported as performance counters.
-  uintx size = _virtual_space.reserved_size();
   _max_survivor_size = compute_survivor_size(size, SpaceAlignment);
   _max_eden_size = size - (2*_max_survivor_size);
 
@@ -252,7 +261,7 @@ DefNewGeneration::DefNewGeneration(ReservedSpace rs,
 
   // Generation counters -- generation 0, 3 subspaces
   _gen_counters = new GenerationCounters("new", 0, 3,
-      min_size, max_size, _virtual_space.committed_size());
+      min_size, max_size, _committed.byte_size());
   _gc_counters = new CollectorCounters(policy, 0);
 
   _eden_counters = new CSpaceCounters("eden", 0, _max_eden_size, _eden_space,
@@ -262,7 +271,7 @@ DefNewGeneration::DefNewGeneration(ReservedSpace rs,
   _to_counters = new CSpaceCounters("s1", 2, _max_survivor_size, _to_space,
                                     _gen_counters);
 
-  compute_space_boundaries(0, SpaceDecorator::Clear, SpaceDecorator::Mangle);
+  compute_space_boundaries(0, SpaceDecorator::Clear, SpaceDecorator::Mangle, (char*)_committed.start());
   update_counters();
   _old_gen = nullptr;
   _tenuring_threshold = MaxTenuringThreshold;
@@ -277,7 +286,8 @@ DefNewGeneration::DefNewGeneration(ReservedSpace rs,
 
 void DefNewGeneration::compute_space_boundaries(uintx minimum_eden_size,
                                                 bool clear_space,
-                                                bool mangle_space) {
+                                                bool mangle_space,
+                                                char* eden_start) {
   // If the spaces are being cleared (only done at heap initialization
   // currently), the survivor spaces need not be empty.
   // Otherwise, no care is taken for used areas in the survivor spaces
@@ -286,7 +296,7 @@ void DefNewGeneration::compute_space_boundaries(uintx minimum_eden_size,
     "Initialization of the survivor spaces assumes these are empty");
 
   // Compute sizes
-  uintx size = _virtual_space.committed_size();
+  uintx size = committed_size();
   uintx survivor_size = compute_survivor_size(size, SpaceAlignment);
   uintx eden_size = size - (2*survivor_size);
   if (eden_size > max_eden_size()) {
@@ -311,12 +321,14 @@ void DefNewGeneration::compute_space_boundaries(uintx minimum_eden_size,
     assert(eden_size >= minimum_eden_size, "just checking");
   }
 
-  char *eden_start = _virtual_space.low();
   char *from_start = eden_start + eden_size;
   char *to_start   = from_start + survivor_size;
   char *to_end     = to_start   + survivor_size;
 
-  assert(to_end == _virtual_space.high(), "just checking");
+  if (!SharedSerialGCVirtualSpace) {
+    assert(to_end == _virtual_space.high(), "just checking");
+  }
+
   assert(is_aligned(eden_start, SpaceAlignment), "checking alignment");
   assert(is_aligned(from_start, SpaceAlignment), "checking alignment");
   assert(is_aligned(to_start, SpaceAlignment),   "checking alignment");
@@ -404,21 +416,38 @@ size_t DefNewGeneration::adjust_for_thread_increase(size_t new_size_candidate,
   return desired_new_size;
 }
 
-void DefNewGeneration::compute_new_size() {
+size_t DefNewGeneration::committed_size() const {
+  if (!SharedSerialGCVirtualSpace) {
+    return _virtual_space.committed_size();
+  } else {
+    MemRegion young_region = SerialHeap::heap()->shared_virtual_space()->young_region();
+    return young_region.byte_size();
+  }
+}
+
+size_t DefNewGeneration::compute_new_size(size_t* thread_incr_size, int* thread_count) {
+  size_t new_size_before = committed_size();
+
   // This is called after a GC that includes the old generation, so from-space
   // will normally be empty.
   // Note that we check both spaces, since if scavenge failed they revert roles.
   // If not we bail out (otherwise we would have to relocate the objects).
   if (!from()->is_empty() || !to()->is_empty()) {
-    return;
+    return new_size_before;
   }
 
   SerialHeap* gch = SerialHeap::heap();
 
   size_t old_size = gch->old_gen()->capacity();
-  size_t new_size_before = _virtual_space.committed_size();
   size_t min_new_size = NewSize;
-  size_t max_new_size = reserved().byte_size();
+
+  size_t max_new_size;
+  if (SharedSerialGCVirtualSpace) {
+    max_new_size = gch->shared_virtual_space()->max_new_size();
+  } else {
+    max_new_size = reserved().byte_size();
+  }
+  assert(max_new_size != 0, "max_new_size must not be 0");
   assert(min_new_size <= new_size_before &&
          new_size_before <= max_new_size,
          "just checking");
@@ -438,6 +467,25 @@ void DefNewGeneration::compute_new_size() {
   desired_new_size = clamp(desired_new_size, min_new_size, max_new_size);
   assert(desired_new_size <= max_new_size, "just checking");
 
+  if (thread_incr_size != nullptr) {
+    *thread_incr_size = thread_increase_size;
+  }
+
+  if (thread_count != nullptr) {
+    *thread_count = threads_count;
+  }
+
+  return desired_new_size;
+}
+
+void DefNewGeneration::resize() {
+  assert(!SharedSerialGCVirtualSpace, "must not be called when SharedSerialGCVirtualSpace is enabled");
+  size_t thread_increase_size = 0;
+  int threads_count = 0;
+
+  size_t new_size_before = committed_size();
+  size_t desired_new_size = compute_new_size(&thread_increase_size, &threads_count);
+  size_t alignment = Generation::GenGrain;
   bool changed = false;
   if (desired_new_size > new_size_before) {
     size_t change = desired_new_size - new_size_before;
@@ -463,10 +511,11 @@ void DefNewGeneration::compute_new_size() {
     // Mangling was done when the heap was being expanded.
     compute_space_boundaries(eden()->used(),
                              SpaceDecorator::Clear,
-                             SpaceDecorator::DontMangle);
+                             SpaceDecorator::DontMangle,
+                             _virtual_space.low());
     MemRegion cmr((HeapWord*)_virtual_space.low(),
                   (HeapWord*)_virtual_space.high());
-    gch->rem_set()->resize_covered_region(cmr);
+    SerialHeap::heap()->rem_set()->resize_covered_region(cmr);
 
     log_debug(gc, ergo, heap)(
         "New generation size %zuK->%zuK [eden=%zuK,survivor=%zuK]",
@@ -475,14 +524,42 @@ void DefNewGeneration::compute_new_size() {
     log_trace(gc, ergo, heap)(
         "  [allowed %zuK extra for %d threads]",
           thread_increase_size/K, threads_count);
-      }
+  }
 }
 
 void DefNewGeneration::ref_processor_init() {
   assert(_ref_processor == nullptr, "a reference processor already exists");
-  assert(!_reserved.is_empty(), "empty generation?");
-  _span_based_discoverer.set_span(_reserved);
+
+  if (SharedSerialGCVirtualSpace) {
+    update_span_based_discoverer_to_committed_range();
+  } else {
+    assert(!_reserved.is_empty(), "empty generation?");
+    _span_based_discoverer.set_span(_reserved);
+  }
+
   _ref_processor = new ReferenceProcessor(&_span_based_discoverer);    // a vanilla reference processor
+}
+
+void DefNewGeneration::update_span_based_discoverer_to_committed_range() {
+  assert(SharedSerialGCVirtualSpace, "must only be called when SharedSerialGCVirtualSpace is enabled");
+  assert(_reserved.is_empty(), "_reserved must be empty in young generation");
+  _span_based_discoverer.set_span(_committed);
+}
+
+void DefNewGeneration::post_shared_virtual_space_resize(size_t young_gen_size_before) {
+  assert(SharedSerialGCVirtualSpace, "must only be called when SharedSerialGCVirtualSpace is enabled");
+  _committed = SerialHeap::heap()->shared_virtual_space()->young_region();
+  update_span_based_discoverer_to_committed_range();
+
+  compute_space_boundaries(eden()->used(),
+                           SpaceDecorator::Clear,
+                           SpaceDecorator::DontMangle,
+                           (char*)_committed.start());
+
+  log_debug(gc, ergo, heap)(
+      "New generation size %zuK->%zuK [eden=%zuK,survivor=%zuK]",
+      young_gen_size_before/K, _committed.byte_size()/K,
+      eden()->capacity()/K, from()->capacity()/K);
 }
 
 size_t DefNewGeneration::capacity() const {
@@ -816,7 +893,7 @@ void DefNewGeneration::update_counters() {
     _eden_counters->update_all();
     _from_counters->update_all();
     _to_counters->update_all();
-    _gen_counters->update_all(_virtual_space.committed_size());
+    _gen_counters->update_all(committed_size());
   }
 }
 
@@ -831,10 +908,26 @@ void DefNewGeneration::print_on(outputStream* st) const {
 
   st->print(" total %zuK, used %zuK",
             capacity()/K, used()/K);
+
+  char* low_boundary;
+  char* high;
+  char* high_boundary;
+
+  if (!SharedSerialGCVirtualSpace) {
+    low_boundary = _virtual_space.low_boundary();
+    high = _virtual_space.high();
+    high_boundary = _virtual_space.high_boundary();
+  } else {
+    MemRegion young_region = SerialHeap::heap()->shared_virtual_space()->young_region();
+    low_boundary = (char*)young_region.start();
+    high_boundary = (char*)young_region.end();
+    high = high_boundary;
+  }
+
   st->print_cr(" [" PTR_FORMAT ", " PTR_FORMAT ", " PTR_FORMAT ")",
-               p2i(_virtual_space.low_boundary()),
-               p2i(_virtual_space.high()),
-               p2i(_virtual_space.high_boundary()));
+    p2i(low_boundary),
+    p2i(high),
+    p2i(high_boundary));
 
   st->print("  eden");
   eden()->print_on(st);

--- a/src/hotspot/share/gc/serial/defNewGeneration.cpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.cpp
@@ -141,16 +141,12 @@ class CLDScanClosure: public CLDClosure {
 };
 
 class IsAliveClosure: public BoolObjectClosure {
-  DefNewGeneration* _young_gen;
+  HeapWord*         _young_gen_end;
 public:
-  IsAliveClosure(DefNewGeneration* g):
-    _young_gen(g) {}
+  IsAliveClosure(DefNewGeneration* g): _young_gen_end(g->reserved().end()) {}
 
   bool do_object_b(oop p) {
-    HeapWord* heap_word_ptr = cast_from_oop<HeapWord*>(p);
-    bool is_in_young_gen = _young_gen->is_in_reserved((void*)heap_word_ptr);
-
-    return (!is_in_young_gen) || p->is_forwarded();
+    return cast_from_oop<HeapWord*>(p) >= _young_gen_end || p->is_forwarded();
   }
 };
 
@@ -177,10 +173,11 @@ class AdjustWeakRootClosure: public OffHeapScanClosure {
 
 class KeepAliveClosure: public OopClosure {
   DefNewGeneration* _young_gen;
+  HeapWord*         _young_gen_end;
   CardTableRS* _rs;
 
   bool is_in_young_gen(void* p) const {
-    return _young_gen->is_in_reserved(p);
+    return p < _young_gen_end;
   }
 
   template <class T>
@@ -200,6 +197,7 @@ class KeepAliveClosure: public OopClosure {
 public:
   KeepAliveClosure(DefNewGeneration* g) :
     _young_gen(g),
+    _young_gen_end(g->reserved().end()),
     _rs(SerialHeap::heap()->rem_set()) {}
 
   void do_oop(oop* p)       { do_oop_work(p); }

--- a/src/hotspot/share/gc/serial/defNewGeneration.hpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.hpp
@@ -221,7 +221,7 @@ class DefNewGeneration: public Generation {
   void reset_scratch();
 
   // GC support
-  inline size_t committed_size() const;
+  size_t committed_size() const;
   size_t compute_new_size(size_t* thread_incr_size = nullptr, int* thread_count = nullptr);
   void resize();
   void post_shared_virtual_space_resize(size_t young_gen_size_before);

--- a/src/hotspot/share/gc/serial/defNewGeneration.hpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.hpp
@@ -133,6 +133,8 @@ class DefNewGeneration: public Generation {
     return n > alignment ? align_down(n, alignment) : alignment;
   }
 
+  void update_span_based_discoverer_to_committed_range();
+
  public:
   DefNewGeneration(ReservedSpace rs,
                    size_t initial_byte_size,
@@ -217,7 +219,10 @@ class DefNewGeneration: public Generation {
   void reset_scratch();
 
   // GC support
-  void compute_new_size();
+  inline size_t committed_size() const;
+  size_t compute_new_size(size_t* thread_incr_size = nullptr, int* thread_count = nullptr);
+  void resize();
+  void post_shared_virtual_space_resize(size_t young_gen_size_before);
 
   bool collect(bool clear_all_soft_refs);
 
@@ -246,7 +251,8 @@ class DefNewGeneration: public Generation {
   // is true, also mangle the space in debug mode.
   void compute_space_boundaries(uintx minimum_eden_size,
                                 bool clear_space,
-                                bool mangle_space);
+                                bool mangle_space,
+                                char* eden_start);
 
   // Return adjusted new size for NewSizeThreadIncrease.
   // If any overflow happens, revert to previous new size.

--- a/src/hotspot/share/gc/serial/defNewGeneration.hpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.hpp
@@ -119,7 +119,7 @@ class DefNewGeneration: public Generation {
   ContiguousSpace* _eden_space;
   ContiguousSpace* _from_space;
   ContiguousSpace* _to_space;
-  HeapWord* _old_gen_boundary;
+  HeapWord* _gen_boundary;
 
   STWGCTimer* _gc_timer;
 
@@ -158,7 +158,7 @@ class DefNewGeneration: public Generation {
   size_t free() const;
   size_t max_capacity() const;
   size_t capacity_before_gc() const;
-  HeapWord* old_gen_boundary() const { return _old_gen_boundary; }
+  HeapWord* gen_boundary() const { return _gen_boundary; }
 
   // Returns "TRUE" iff "p" points into the used areas in each space of young-gen.
   bool is_in(const void* p) const;

--- a/src/hotspot/share/gc/serial/defNewGeneration.hpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.hpp
@@ -119,6 +119,7 @@ class DefNewGeneration: public Generation {
   ContiguousSpace* _eden_space;
   ContiguousSpace* _from_space;
   ContiguousSpace* _to_space;
+  HeapWord* _old_gen_boundary;
 
   STWGCTimer* _gc_timer;
 
@@ -157,6 +158,7 @@ class DefNewGeneration: public Generation {
   size_t free() const;
   size_t max_capacity() const;
   size_t capacity_before_gc() const;
+  HeapWord* old_gen_boundary() const { return _old_gen_boundary; }
 
   // Returns "TRUE" iff "p" points into the used areas in each space of young-gen.
   bool is_in(const void* p) const;

--- a/src/hotspot/share/gc/serial/generation.hpp
+++ b/src/hotspot/share/gc/serial/generation.hpp
@@ -25,8 +25,8 @@
 #ifndef SHARE_GC_SERIAL_GENERATION_HPP
 #define SHARE_GC_SERIAL_GENERATION_HPP
 
-#include "gc/serial/serial_globals.hpp"
 #include "gc/shared/collectorCounters.hpp"
+#include "gc/shared/gc_globals.hpp"
 #include "gc/shared/referenceProcessor.hpp"
 #include "gc/shared/space.hpp"
 #include "logging/log.hpp"

--- a/src/hotspot/share/gc/serial/generation.hpp
+++ b/src/hotspot/share/gc/serial/generation.hpp
@@ -25,6 +25,7 @@
 #ifndef SHARE_GC_SERIAL_GENERATION_HPP
 #define SHARE_GC_SERIAL_GENERATION_HPP
 
+#include "gc/serial/serial_globals.hpp"
 #include "gc/shared/collectorCounters.hpp"
 #include "gc/shared/referenceProcessor.hpp"
 #include "gc/shared/space.hpp"
@@ -68,6 +69,9 @@ class Generation: public CHeapObj<mtGC> {
   // other generations.
   MemRegion _reserved;
 
+  // addresses for committed memory for this generation
+  MemRegion _committed;
+
   // Memory area reserved for generation
   VirtualSpace _virtual_space;
 
@@ -101,7 +105,7 @@ class Generation: public CHeapObj<mtGC> {
 
   /* Returns "TRUE" iff "p" points into the reserved area of the generation. */
   bool is_in_reserved(const void* p) const {
-    return _reserved.contains(p);
+    return !SharedSerialGCVirtualSpace ? _reserved.contains(p) : _committed.contains(p);
   }
 
   virtual void verify() = 0;

--- a/src/hotspot/share/gc/serial/serialGCVirtualSpace.cpp
+++ b/src/hotspot/share/gc/serial/serialGCVirtualSpace.cpp
@@ -151,7 +151,8 @@ bool SerialGCVirtualSpace::resize(size_t young_gen_size) {
   }
 
   size_t new_capacity = committed_size();
-  log_trace(gc, heap)("SerialGCVirtualSpace size %6.1fK->%6.1fK [young=%6.1fK,tenured=%6.1fK]",
+  log_trace(gc, heap)("SerialGCVirtualSpace size %s: %6.1fK->%6.1fK [young=%6.1fK,tenured=%6.1fK]",
+                      new_capacity == prev_capacity ? "unchanged" : "changed",
                       prev_capacity / (double) K,
                       new_capacity / (double) K,
                       _young_region.byte_size() / (double) K,

--- a/src/hotspot/share/gc/serial/serialGCVirtualSpace.cpp
+++ b/src/hotspot/share/gc/serial/serialGCVirtualSpace.cpp
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "gc/serial/serialGCVirtualSpace.hpp"
+#include "gc/shared/genArguments.hpp"
+#include "gc/shared/spaceDecorator.hpp"
+#include "logging/log.hpp"
+#include "runtime/java.hpp"
+
+// See os::is_server_class_machine()
+const julong server_memory     = 2UL * G;
+const julong missing_memory   = 256UL * M;
+
+size_t SerialGCVirtualSpace::max_new_size() const {
+  return server_memory - missing_memory;
+}
+
+void SerialGCVirtualSpace::initialize(ReservedSpace rs, size_t old_size, size_t new_size) {
+  assert(old_size != 0, "old_size must not be 0");
+  assert(new_size != 0, "new_size must not be 0");
+
+  size_t initial_virtual_space_size = old_size + new_size;
+  if (!_ahs_virtual_space.initialize(rs, initial_virtual_space_size)) {
+    vm_exit_during_initialization("Could not reserve enough space for object heap");
+  }
+
+  _heap_region = MemRegion((HeapWord*)_ahs_virtual_space.low(), (HeapWord*)_ahs_virtual_space.high());
+
+  // Mangle all of the initial generations.
+  if (ZapUnusedHeapArea) {
+    SpaceMangler::mangle_region(_heap_region);
+  }
+
+  MemRegion tenured_region((HeapWord*)_ahs_virtual_space.low(), heap_word_size(OldSize));
+  assert(tenured_region.byte_size() == old_size, "_tenured_region size in bytes must match old_size");
+  set_tenured_region(tenured_region);
+
+  MemRegion young_region = _heap_region.minus(_tenured_region);
+  assert(young_region.byte_size() == new_size, "_young_region size in bytes must match new_size");
+  set_young_region(young_region);
+}
+
+size_t SerialGCVirtualSpace::committed_size() {
+  return _ahs_virtual_space.committed_size();
+}
+
+void SerialGCVirtualSpace::set_tenured_region(MemRegion region) {
+  log_trace(gc, heap)("SerialGCVirtualSpace updating tenured region: ");
+  log_trace(gc, heap)("   from _tenured_region.start(): " PTR_FORMAT " _tenured_region.end(): " PTR_FORMAT,
+                      p2i(_tenured_region.start()), p2i(_tenured_region.end()));
+  log_trace(gc, heap)("   to            region.start(): " PTR_FORMAT "          region.end(): " PTR_FORMAT,
+                      p2i(region.start()), p2i(region.end()));
+  _tenured_region = region;
+}
+
+void SerialGCVirtualSpace::set_young_region(MemRegion region) {
+  log_trace(gc, heap)("SerialGCVirtualSpace updating young region: ");
+  log_trace(gc, heap)("   from _young_region.start(): " PTR_FORMAT " _young_region.end(): " PTR_FORMAT,
+                      p2i(_young_region.start()), p2i(_young_region.end()));
+  log_trace(gc, heap)("   to          region.start(): " PTR_FORMAT "        region.end(): " PTR_FORMAT,
+                      p2i(region.start()), p2i(region.end()));
+  _young_region = region;
+}
+
+bool SerialGCVirtualSpace::resize_virtual_space(size_t tenured_gen_size, size_t young_gen_size) {
+  size_t curr_capacity = committed_size();
+  size_t new_capacity = tenured_gen_size + young_gen_size;
+
+  bool success;
+
+  if (new_capacity > curr_capacity) {
+    size_t expand_bytes = new_capacity - curr_capacity;
+    if (expand_bytes < MinHeapDeltaBytes) {
+      // Always expand by at least MinHeapDeltaBytes
+      expand_bytes = MinHeapDeltaBytes;
+    }
+
+    success = expand_by(expand_bytes);
+    log_trace(gc, heap)("SerialGCVirtualSpace attempting expansion:  new_capacity: %6.1fK  expand_bytes: %6.1fK  MinHeapDeltaBytes: %6.1fK  success: %d",
+                  new_capacity / (double) K,
+                  expand_bytes / (double) K,
+                  MinHeapDeltaBytes / (double) K,
+                  success);
+  } else if (new_capacity < curr_capacity) {
+    size_t shrink_bytes = curr_capacity - new_capacity;
+    shrink_by(shrink_bytes);
+    success = true;
+  }
+
+  if (success) {
+    _heap_region = MemRegion((HeapWord*)_ahs_virtual_space.low(), (HeapWord*)_ahs_virtual_space.high());
+  }
+  return success;
+}
+
+bool SerialGCVirtualSpace::resize(size_t tenured_gen_size, size_t young_gen_size) {
+  assert(tenured_gen_size > 0, "tenured_gen_size must not be 0");
+  assert(young_gen_size > 0, "young_gen_size must not be 0");
+
+  size_t curr_capacity = committed_size();
+  bool success = resize_virtual_space(tenured_gen_size, young_gen_size);
+  size_t new_capacity = committed_size();
+
+  if (success) {
+    // update young and tenured regions
+    MemRegion tr(_tenured_region.start(), heap_word_size(tenured_gen_size));
+    MemRegion yr = _heap_region.minus(tr);
+    set_tenured_region(tr);
+    set_young_region(yr);
+  }
+
+  log_trace(gc, heap)("SerialGCVirtualSpace size %6.1fK->%6.1fK [young=%6.1fK,tenured=%6.1fK]",
+                      curr_capacity / (double) K,
+                      new_capacity / (double) K,
+                      _young_region.byte_size() / (double) K,
+                      _tenured_region.byte_size() / (double) K);
+
+  return success;
+}
+
+bool SerialGCVirtualSpace::resize(size_t young_gen_size) {
+  assert(young_gen_size > 0, "young_gen_size must not be 0");
+
+  size_t prev_capacity = committed_size();
+  bool success = resize_virtual_space(_tenured_region.byte_size(), young_gen_size);
+
+  if (success) {
+    MemRegion young_region = _heap_region.minus(_tenured_region);
+    set_young_region(young_region);
+  }
+
+  size_t new_capacity = committed_size();
+  log_trace(gc, heap)("SerialGCVirtualSpace size %6.1fK->%6.1fK [young=%6.1fK,tenured=%6.1fK]",
+                      prev_capacity / (double) K,
+                      new_capacity / (double) K,
+                      _young_region.byte_size() / (double) K,
+                      _tenured_region.byte_size() / (double) K);
+
+  return success;
+}
+
+bool SerialGCVirtualSpace::expand_by(size_t bytes, bool pre_touch) {
+  HeapWord* prev_high = (HeapWord*)_ahs_virtual_space.high();
+  bool success = _ahs_virtual_space.expand_by(bytes, pre_touch);
+
+  if (success) {
+    _heap_region = MemRegion((HeapWord*)_ahs_virtual_space.low(), (HeapWord*)_ahs_virtual_space.high());
+
+    if (ZapUnusedHeapArea) {
+      HeapWord* new_high = (HeapWord*) _ahs_virtual_space.high();
+      MemRegion mangle_region(prev_high, new_high);
+      SpaceMangler::mangle_region(mangle_region);
+    }
+  }
+
+  return success;
+}
+
+void SerialGCVirtualSpace::shrink_by(size_t size) {
+  _ahs_virtual_space.shrink_by(size);
+  _heap_region = MemRegion((HeapWord*)_ahs_virtual_space.low(), (HeapWord*)_ahs_virtual_space.high());
+}

--- a/src/hotspot/share/gc/serial/serialGCVirtualSpace.cpp
+++ b/src/hotspot/share/gc/serial/serialGCVirtualSpace.cpp
@@ -41,18 +41,18 @@ void SerialGCVirtualSpace::initialize(ReservedSpace rs, size_t old_size, size_t 
   assert(new_size != 0, "new_size must not be 0");
 
   size_t initial_virtual_space_size = old_size + new_size;
-  if (!_ahs_virtual_space.initialize(rs, initial_virtual_space_size)) {
+  if (!_virtual_space.initialize(rs, initial_virtual_space_size)) {
     vm_exit_during_initialization("Could not reserve enough space for object heap");
   }
 
-  _heap_region = MemRegion((HeapWord*)_ahs_virtual_space.low(), (HeapWord*)_ahs_virtual_space.high());
+  _heap_region = MemRegion((HeapWord*)_virtual_space.low(), (HeapWord*)_virtual_space.high());
 
   // Mangle all of the initial generations.
   if (ZapUnusedHeapArea) {
     SpaceMangler::mangle_region(_heap_region);
   }
 
-  MemRegion tenured_region((HeapWord*)_ahs_virtual_space.low(), heap_word_size(OldSize));
+  MemRegion tenured_region((HeapWord*)_virtual_space.low(), heap_word_size(OldSize));
   assert(tenured_region.byte_size() == old_size, "_tenured_region size in bytes must match old_size");
   set_tenured_region(tenured_region);
 
@@ -62,7 +62,7 @@ void SerialGCVirtualSpace::initialize(ReservedSpace rs, size_t old_size, size_t 
 }
 
 size_t SerialGCVirtualSpace::committed_size() {
-  return _ahs_virtual_space.committed_size();
+  return _virtual_space.committed_size();
 }
 
 void SerialGCVirtualSpace::set_tenured_region(MemRegion region) {
@@ -109,7 +109,7 @@ bool SerialGCVirtualSpace::resize_virtual_space(size_t tenured_gen_size, size_t 
   }
 
   if (success) {
-    _heap_region = MemRegion((HeapWord*)_ahs_virtual_space.low(), (HeapWord*)_ahs_virtual_space.high());
+    _heap_region = MemRegion((HeapWord*)_virtual_space.low(), (HeapWord*)_virtual_space.high());
   }
   return success;
 }
@@ -161,14 +161,14 @@ bool SerialGCVirtualSpace::resize(size_t young_gen_size) {
 }
 
 bool SerialGCVirtualSpace::expand_by(size_t bytes, bool pre_touch) {
-  HeapWord* prev_high = (HeapWord*)_ahs_virtual_space.high();
-  bool success = _ahs_virtual_space.expand_by(bytes, pre_touch);
+  HeapWord* prev_high = (HeapWord*)_virtual_space.high();
+  bool success = _virtual_space.expand_by(bytes, pre_touch);
 
   if (success) {
-    _heap_region = MemRegion((HeapWord*)_ahs_virtual_space.low(), (HeapWord*)_ahs_virtual_space.high());
+    _heap_region = MemRegion((HeapWord*)_virtual_space.low(), (HeapWord*)_virtual_space.high());
 
     if (ZapUnusedHeapArea) {
-      HeapWord* new_high = (HeapWord*) _ahs_virtual_space.high();
+      HeapWord* new_high = (HeapWord*) _virtual_space.high();
       MemRegion mangle_region(prev_high, new_high);
       SpaceMangler::mangle_region(mangle_region);
     }
@@ -178,6 +178,6 @@ bool SerialGCVirtualSpace::expand_by(size_t bytes, bool pre_touch) {
 }
 
 void SerialGCVirtualSpace::shrink_by(size_t size) {
-  _ahs_virtual_space.shrink_by(size);
-  _heap_region = MemRegion((HeapWord*)_ahs_virtual_space.low(), (HeapWord*)_ahs_virtual_space.high());
+  _virtual_space.shrink_by(size);
+  _heap_region = MemRegion((HeapWord*)_virtual_space.low(), (HeapWord*)_virtual_space.high());
 }

--- a/src/hotspot/share/gc/serial/serialGCVirtualSpace.hpp
+++ b/src/hotspot/share/gc/serial/serialGCVirtualSpace.hpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef SHARE_GC_SERIAL_SERIALGCVIRTUALSPACE_HPP
+#define SHARE_GC_SERIAL_SERIALGCVIRTUALSPACE_HPP
+
+#include "memory/allocation.hpp"
+#include "memory/memRegion.hpp"
+#include "memory/reservedSpace.hpp"
+#include "memory/virtualspace.hpp"
+
+class SerialGCVirtualSpace: public CHeapObj<mtInternal> {
+private:
+  VirtualSpace _ahs_virtual_space;
+  MemRegion _heap_region;
+
+  MemRegion _tenured_region;
+  MemRegion _young_region;
+
+  // returns true on success, false otherwise
+  bool expand_by(size_t bytes, bool pre_touch = false);
+  void shrink_by(size_t bytes);
+  bool resize_virtual_space(size_t tenured_gen_size, size_t young_gen_size);
+
+public:
+  SerialGCVirtualSpace() {}
+
+  void initialize(ReservedSpace rs, size_t old_size, size_t new_size);
+
+  inline size_t committed_size();
+
+  MemRegion tenured_region() { return _tenured_region; }
+  MemRegion young_region() { return _young_region; }
+
+  void set_tenured_region(MemRegion region);
+  void set_young_region(MemRegion region);
+
+  bool resize(size_t young_gen_size);
+  bool resize(size_t tenured_gen_size, size_t young_gen_size);
+
+  size_t max_new_size() const;
+};
+
+#endif // SHARE_GC_SERIAL_SERIALGCVIRTUALSPACE_HPP

--- a/src/hotspot/share/gc/serial/serialGCVirtualSpace.hpp
+++ b/src/hotspot/share/gc/serial/serialGCVirtualSpace.hpp
@@ -32,7 +32,7 @@
 
 class SerialGCVirtualSpace: public CHeapObj<mtInternal> {
 private:
-  VirtualSpace _ahs_virtual_space;
+  VirtualSpace _virtual_space;
   MemRegion _heap_region;
 
   MemRegion _tenured_region;

--- a/src/hotspot/share/gc/serial/serialHeap.cpp
+++ b/src/hotspot/share/gc/serial/serialHeap.cpp
@@ -459,15 +459,17 @@ bool SerialHeap::do_young_collection(bool clear_soft_refs) {
   }
 
   if (SharedSerialGCVirtualSpace) {
-    size_t young_gen_size_before = _shared_virtual_space->young_region().byte_size();
+    size_t young_gen_size_before = _young_gen->committed_size();
     size_t young_gen_size = _young_gen->compute_new_size();
 
-    // execution will continue with the existing heap generation sizes if resizing the VirtualSpace fails
-    bool success = _shared_virtual_space->resize(young_gen_size);
-    if (success) {
-      _young_gen->post_shared_virtual_space_resize(young_gen_size_before);
-      rem_set()->resize_covered_region_in_shared_virtual_space(_shared_virtual_space->tenured_region(),
-                                                            _shared_virtual_space->young_region());
+    if (young_gen_size != young_gen_size_before) {
+      // execution will continue with the existing heap generation sizes if resizing the VirtualSpace fails
+      bool success = _shared_virtual_space->resize(young_gen_size);
+      if (success) {
+        _young_gen->post_shared_virtual_space_resize(young_gen_size_before);
+        rem_set()->resize_covered_region_in_shared_virtual_space(_shared_virtual_space->tenured_region(),
+                                                                 _shared_virtual_space->young_region());
+      }
     }
   } else {
     _young_gen->resize();

--- a/src/hotspot/share/gc/serial/serialHeap.cpp
+++ b/src/hotspot/share/gc/serial/serialHeap.cpp
@@ -704,10 +704,7 @@ void SerialHeap::do_full_collection(bool clear_all_soft_refs) {
 }
 
 bool SerialHeap::is_in_young(const void* p) const {
-  bool result = p < _old_gen->reserved().start();
-  assert(result == _young_gen->is_in_reserved(p),
-         "incorrect test - result=%d, p=" PTR_FORMAT, result, p2i(p));
-  return result;
+  return _young_gen->is_in_reserved(p);
 }
 
 bool SerialHeap::requires_barriers(stackChunkOop obj) const {

--- a/src/hotspot/share/gc/serial/serialHeap.cpp
+++ b/src/hotspot/share/gc/serial/serialHeap.cpp
@@ -198,7 +198,7 @@ jint SerialHeap::initialize() {
   if (SwapSerialGCGenerations) {
     ReservedSpace old_rs = heap_rs.first_part(MaxOldSize, GenAlignment);
     ReservedSpace young_rs = heap_rs.last_part(MaxOldSize, GenAlignment);
-    _old_gen_boundary = young_rs.base();
+    _gen_boundary = young_rs.base();
 
     if (SharedSerialGCVirtualSpace) {
       MemRegion tenured_region = _shared_virtual_space->tenured_region();
@@ -217,7 +217,7 @@ jint SerialHeap::initialize() {
   } else {
     ReservedSpace young_rs = heap_rs.first_part(MaxNewSize, GenAlignment);
     ReservedSpace old_rs = heap_rs.last_part(MaxNewSize, GenAlignment);
-    _old_gen_boundary = old_rs.base();
+    _gen_boundary = old_rs.base();
 
     _rem_set->initialize(young_rs.base(), old_rs.base());
     _young_gen = new DefNewGeneration(young_rs, NewSize, MinNewSize, MaxNewSize);
@@ -759,7 +759,7 @@ void SerialHeap::do_full_collection(bool clear_all_soft_refs) {
 }
 
 bool SerialHeap::is_in_young(const void* p) const {
-  bool is_in_lower_region = p < _old_gen_boundary;
+  bool is_in_lower_region = p < _gen_boundary;
   bool result = SwapSerialGCGenerations ^ is_in_lower_region;
 
   assert(result == _young_gen->is_in_reserved(p),

--- a/src/hotspot/share/gc/serial/serialHeap.cpp
+++ b/src/hotspot/share/gc/serial/serialHeap.cpp
@@ -459,6 +459,7 @@ bool SerialHeap::do_young_collection(bool clear_soft_refs) {
     size_t young_gen_size_before = _shared_virtual_space->young_region().byte_size();
     size_t young_gen_size = _young_gen->compute_new_size();
 
+    // execution will continue with the existing heap generation sizes if resizing the VirtualSpace fails
     bool success = _shared_virtual_space->resize(young_gen_size);
     if (success) {
       _young_gen->post_shared_virtual_space_resize(young_gen_size_before);
@@ -713,6 +714,7 @@ void SerialHeap::do_full_collection(bool clear_all_soft_refs) {
     size_t tenured_gen_size = _old_gen->compute_new_size();
     size_t young_gen_size = _young_gen->compute_new_size();
 
+    // execution will continue with the existing heap generation sizes if resizing the VirtualSpace fails
     bool success = _shared_virtual_space->resize(tenured_gen_size, young_gen_size);
     if (success) {
       _young_gen->post_shared_virtual_space_resize(young_gen_size_before);

--- a/src/hotspot/share/gc/serial/serialHeap.cpp
+++ b/src/hotspot/share/gc/serial/serialHeap.cpp
@@ -188,12 +188,28 @@ jint SerialHeap::initialize() {
 
   initialize_reserved_region(heap_rs);
 
+  if (SharedSerialGCVirtualSpace) {
+    _shared_virtual_space = new SerialGCVirtualSpace();
+    _shared_virtual_space->initialize(heap_rs, OldSize, NewSize);
+  }
+
   _rem_set = new CardTableRS(_reserved);
 
   if (SwapSerialGCGenerations) {
     ReservedSpace old_rs = heap_rs.first_part(MaxOldSize, GenAlignment);
     ReservedSpace young_rs = heap_rs.last_part(MaxOldSize, GenAlignment);
-    _rem_set->initialize(old_rs.base(), young_rs.base());
+
+    if (SharedSerialGCVirtualSpace) {
+      MemRegion tenured_region = _shared_virtual_space->tenured_region();
+      MemRegion young_region = _shared_virtual_space->young_region();
+      assert(young_region.start() == tenured_region.end(),
+             "region1 must start at the end of region0");
+
+      _rem_set->initialize((void*)tenured_region.start(), (void*)young_region.start());
+    } else {
+      _rem_set->initialize(old_rs.base(), young_rs.base());
+    }
+
     _young_gen = new DefNewGeneration(young_rs, NewSize, MinNewSize, MaxNewSize);
     _old_gen = new TenuredGeneration(old_rs, OldSize, MinOldSize, MaxOldSize, rem_set());
   } else {
@@ -299,7 +315,8 @@ bool SerialHeap::should_try_older_generation_allocation(size_t word_size) const 
 
 HeapWord* SerialHeap::expand_heap_and_allocate(size_t size, bool is_tlab) {
   HeapWord* result = nullptr;
-  if (_old_gen->should_allocate(size, is_tlab)) {
+  // Old gen cannot be expanded independently when SharedSerialGCVirtualSpace is enabled
+  if (!SharedSerialGCVirtualSpace && _old_gen->should_allocate(size, is_tlab)) {
     result = _old_gen->expand_and_allocate(size);
   }
   if (result == nullptr) {
@@ -438,7 +455,19 @@ bool SerialHeap::do_young_collection(bool clear_soft_refs) {
     Universe::verify("After GC");
   }
 
-  _young_gen->compute_new_size();
+  if (SharedSerialGCVirtualSpace) {
+    size_t young_gen_size_before = _shared_virtual_space->young_region().byte_size();
+    size_t young_gen_size = _young_gen->compute_new_size();
+
+    bool success = _shared_virtual_space->resize(young_gen_size);
+    if (success) {
+      _young_gen->post_shared_virtual_space_resize(young_gen_size_before);
+      rem_set()->resize_covered_region_in_shared_virtual_space(_shared_virtual_space->tenured_region(),
+                                                            _shared_virtual_space->young_region());
+    }
+  } else {
+    _young_gen->resize();
+  }
 
   print_heap_change(pre_gc_values);
 
@@ -679,8 +708,21 @@ void SerialHeap::do_full_collection(bool clear_all_soft_refs) {
   COMPILER2_OR_JVMCI_PRESENT(DerivedPointerTable::update_pointers());
 
   // Adjust generation sizes.
-  _old_gen->compute_new_size();
-  _young_gen->compute_new_size();
+  if (SharedSerialGCVirtualSpace) {
+    size_t young_gen_size_before = _shared_virtual_space->young_region().byte_size();
+    size_t tenured_gen_size = _old_gen->compute_new_size();
+    size_t young_gen_size = _young_gen->compute_new_size();
+
+    bool success = _shared_virtual_space->resize(tenured_gen_size, young_gen_size);
+    if (success) {
+      _young_gen->post_shared_virtual_space_resize(young_gen_size_before);
+      rem_set()->resize_covered_region_in_shared_virtual_space(_shared_virtual_space->tenured_region(),
+                                                          _shared_virtual_space->young_region());
+    }
+  } else {
+    _old_gen->resize();
+    _young_gen->resize();
+  }
 
   // Delete metaspaces for unloaded class loaders and clean up loader_data graph
   ClassLoaderDataGraph::purge(/*at_safepoint*/true);

--- a/src/hotspot/share/gc/serial/serialHeap.cpp
+++ b/src/hotspot/share/gc/serial/serialHeap.cpp
@@ -198,6 +198,7 @@ jint SerialHeap::initialize() {
   if (SwapSerialGCGenerations) {
     ReservedSpace old_rs = heap_rs.first_part(MaxOldSize, GenAlignment);
     ReservedSpace young_rs = heap_rs.last_part(MaxOldSize, GenAlignment);
+    _old_gen_boundary = young_rs.base();
 
     if (SharedSerialGCVirtualSpace) {
       MemRegion tenured_region = _shared_virtual_space->tenured_region();
@@ -210,11 +211,14 @@ jint SerialHeap::initialize() {
       _rem_set->initialize(old_rs.base(), young_rs.base());
     }
 
+    _rem_set->initialize(old_rs.base(), young_rs.base());
     _young_gen = new DefNewGeneration(young_rs, NewSize, MinNewSize, MaxNewSize);
     _old_gen = new TenuredGeneration(old_rs, OldSize, MinOldSize, MaxOldSize, rem_set());
   } else {
     ReservedSpace young_rs = heap_rs.first_part(MaxNewSize, GenAlignment);
     ReservedSpace old_rs = heap_rs.last_part(MaxNewSize, GenAlignment);
+    _old_gen_boundary = old_rs.base();
+
     _rem_set->initialize(young_rs.base(), old_rs.base());
     _young_gen = new DefNewGeneration(young_rs, NewSize, MinNewSize, MaxNewSize);
     _old_gen = new TenuredGeneration(old_rs, OldSize, MinOldSize, MaxOldSize, rem_set());
@@ -755,7 +759,9 @@ void SerialHeap::do_full_collection(bool clear_all_soft_refs) {
 }
 
 bool SerialHeap::is_in_young(const void* p) const {
-  bool result = p < _old_gen->reserved().start();
+  bool is_in_lower_region = p < _old_gen_boundary;
+  bool result = SwapSerialGCGenerations ^ is_in_lower_region;
+
   assert(result == _young_gen->is_in_reserved(p),
          "incorrect test - result=%d, p=" PTR_FORMAT, result, p2i(p));
   return result;

--- a/src/hotspot/share/gc/serial/serialHeap.cpp
+++ b/src/hotspot/share/gc/serial/serialHeap.cpp
@@ -755,7 +755,10 @@ void SerialHeap::do_full_collection(bool clear_all_soft_refs) {
 }
 
 bool SerialHeap::is_in_young(const void* p) const {
-  return _young_gen->is_in_reserved(p);
+  bool result = p < _old_gen->reserved().start();
+  assert(result == _young_gen->is_in_reserved(p),
+         "incorrect test - result=%d, p=" PTR_FORMAT, result, p2i(p));
+  return result;
 }
 
 bool SerialHeap::requires_barriers(stackChunkOop obj) const {

--- a/src/hotspot/share/gc/serial/serialHeap.hpp
+++ b/src/hotspot/share/gc/serial/serialHeap.hpp
@@ -27,6 +27,7 @@
 
 #include "gc/serial/defNewGeneration.hpp"
 #include "gc/serial/generation.hpp"
+#include "gc/serial/serialGCVirtualSpace.hpp"
 #include "gc/serial/tenuredGeneration.hpp"
 #include "gc/shared/collectedHeap.hpp"
 #include "gc/shared/oopStorageParState.hpp"
@@ -259,6 +260,7 @@ private:
   MemoryPool* _eden_pool;
   MemoryPool* _survivor_pool;
   MemoryPool* _old_pool;
+  SerialGCVirtualSpace* _shared_virtual_space;
 
   void initialize_serviceability() override;
 
@@ -299,6 +301,8 @@ public:
 
   void pin_object(JavaThread* thread, oop obj) override;
   void unpin_object(JavaThread* thread, oop obj) override;
+
+  SerialGCVirtualSpace* shared_virtual_space() { return _shared_virtual_space; }
 };
 
 #endif // SHARE_GC_SERIAL_SERIALHEAP_HPP

--- a/src/hotspot/share/gc/serial/serialHeap.hpp
+++ b/src/hotspot/share/gc/serial/serialHeap.hpp
@@ -80,6 +80,7 @@ private:
   TenuredGeneration* _old_gen;
   HeapWord* _young_gen_saved_top;
   HeapWord* _old_gen_saved_top;
+  char* _old_gen_boundary;
 
   // The singleton CardTable Remembered Set.
   CardTableRS* _rem_set;
@@ -161,6 +162,8 @@ public:
   // Returns true if p points into the reserved space for the young generation.
   // Assumes the young gen address range is less than that of the old gen.
   bool is_in_young(const void* p) const;
+
+  char* old_gen_boundary() const { return _old_gen_boundary; }
 
   bool requires_barriers(stackChunkOop obj) const override;
 

--- a/src/hotspot/share/gc/serial/serialHeap.hpp
+++ b/src/hotspot/share/gc/serial/serialHeap.hpp
@@ -80,7 +80,7 @@ private:
   TenuredGeneration* _old_gen;
   HeapWord* _young_gen_saved_top;
   HeapWord* _old_gen_saved_top;
-  char* _old_gen_boundary;
+  char* _gen_boundary;
 
   // The singleton CardTable Remembered Set.
   CardTableRS* _rem_set;
@@ -163,7 +163,7 @@ public:
   // Assumes the young gen address range is less than that of the old gen.
   bool is_in_young(const void* p) const;
 
-  char* old_gen_boundary() const { return _old_gen_boundary; }
+  char* gen_boundary() const { return _gen_boundary; }
 
   bool requires_barriers(stackChunkOop obj) const override;
 

--- a/src/hotspot/share/gc/serial/serialHeap.inline.hpp
+++ b/src/hotspot/share/gc/serial/serialHeap.inline.hpp
@@ -32,14 +32,12 @@
 
 class ScavengeHelper {
   DefNewGeneration* _young_gen;
-  HeapWord*         _young_gen_end;
 public:
   ScavengeHelper(DefNewGeneration* young_gen) :
-    _young_gen(young_gen),
-    _young_gen_end(young_gen->reserved().end()) {}
+    _young_gen(young_gen) {}
 
   bool is_in_young_gen(void* p) const {
-    return p < _young_gen_end;
+    return _young_gen->is_in_reserved(p);
   }
 
   template <typename T, typename Func>

--- a/src/hotspot/share/gc/serial/serialHeap.inline.hpp
+++ b/src/hotspot/share/gc/serial/serialHeap.inline.hpp
@@ -32,14 +32,15 @@
 
 class ScavengeHelper {
   DefNewGeneration* _young_gen;
-  HeapWord*         _young_gen_end;
+  HeapWord*         _old_gen_boundary;
 public:
   ScavengeHelper(DefNewGeneration* young_gen) :
     _young_gen(young_gen),
-    _young_gen_end(young_gen->reserved().end()) {}
+    _old_gen_boundary(young_gen->old_gen_boundary()) {}
 
   bool is_in_young_gen(void* p) const {
-    return p < _young_gen_end;
+    bool is_in_lower_region = p < _old_gen_boundary;
+    return SwapSerialGCGenerations ^ is_in_lower_region;
   }
 
   template <typename T, typename Func>

--- a/src/hotspot/share/gc/serial/serialHeap.inline.hpp
+++ b/src/hotspot/share/gc/serial/serialHeap.inline.hpp
@@ -32,14 +32,14 @@
 
 class ScavengeHelper {
   DefNewGeneration* _young_gen;
-  HeapWord*         _old_gen_boundary;
+  HeapWord*         _gen_boundary;
 public:
   ScavengeHelper(DefNewGeneration* young_gen) :
     _young_gen(young_gen),
-    _old_gen_boundary(young_gen->old_gen_boundary()) {}
+    _gen_boundary(young_gen->gen_boundary()) {}
 
   bool is_in_young_gen(void* p) const {
-    bool is_in_lower_region = p < _old_gen_boundary;
+    bool is_in_lower_region = p < _gen_boundary;
     return SwapSerialGCGenerations ^ is_in_lower_region;
   }
 

--- a/src/hotspot/share/gc/serial/serialHeap.inline.hpp
+++ b/src/hotspot/share/gc/serial/serialHeap.inline.hpp
@@ -32,12 +32,14 @@
 
 class ScavengeHelper {
   DefNewGeneration* _young_gen;
+  HeapWord*         _young_gen_end;
 public:
   ScavengeHelper(DefNewGeneration* young_gen) :
-    _young_gen(young_gen) {}
+    _young_gen(young_gen),
+    _young_gen_end(young_gen->reserved().end()) {}
 
   bool is_in_young_gen(void* p) const {
-    return _young_gen->is_in_reserved(p);
+    return p < _young_gen_end;
   }
 
   template <typename T, typename Func>

--- a/src/hotspot/share/gc/serial/serial_globals.hpp
+++ b/src/hotspot/share/gc/serial/serial_globals.hpp
@@ -35,6 +35,10 @@
           "When disabled, informs the GC to shrink the java heap directly"  \
           " to the target size at the next full GC rather than requiring"   \
           " smaller steps during multiple full GCs.")                       \
+                                                                            \
+  product(bool, SwapSerialGCGenerations, false, EXPERIMENTAL,               \
+          "When enabled, informs the GC to place the tenured region before" \
+          " the young region in memory.")                                   \
 
 // end of GC_SERIAL_FLAGS
 

--- a/src/hotspot/share/gc/serial/serial_globals.hpp
+++ b/src/hotspot/share/gc/serial/serial_globals.hpp
@@ -36,6 +36,10 @@
           " to the target size at the next full GC rather than requiring"   \
           " smaller steps during multiple full GCs.")                       \
                                                                             \
+  product(bool, SharedSerialGCVirtualSpace, false, EXPERIMENTAL,            \
+          "When enabled, informs the GC to use a single VirtualSpace for"   \
+          " both the young and tenured regions.")                           \
+                                                                            \
   product(bool, SwapSerialGCGenerations, false, EXPERIMENTAL,               \
           "When enabled, informs the GC to place the tenured region before" \
           " the young region in memory.")                                   \

--- a/src/hotspot/share/gc/serial/tenuredGeneration.cpp
+++ b/src/hotspot/share/gc/serial/tenuredGeneration.cpp
@@ -42,6 +42,7 @@
 #include "utilities/macros.hpp"
 
 bool TenuredGeneration::grow_by(size_t bytes) {
+  assert(!SharedSerialGCVirtualSpace, "unexpected invocation of grow_by");
   assert_correct_size_change_locking();
   bool result = _virtual_space.expand_by(bytes);
   if (result) {
@@ -75,6 +76,7 @@ bool TenuredGeneration::grow_by(size_t bytes) {
 }
 
 bool TenuredGeneration::expand(size_t bytes, size_t expand_bytes) {
+  assert(!SharedSerialGCVirtualSpace, "unexpected invocation of expand");
   assert_locked_or_safepoint(Heap_lock);
   if (bytes == 0) {
     return true;  // That's what grow_by(0) would return
@@ -105,6 +107,7 @@ bool TenuredGeneration::expand(size_t bytes, size_t expand_bytes) {
 }
 
 bool TenuredGeneration::grow_to_reserved() {
+  assert(!SharedSerialGCVirtualSpace, "unexpected invocation of grow_to_reserved");
   assert_correct_size_change_locking();
   bool success = true;
   const size_t remaining_bytes = _virtual_space.uncommitted_size();
@@ -116,6 +119,7 @@ bool TenuredGeneration::grow_to_reserved() {
 }
 
 void TenuredGeneration::shrink(size_t bytes) {
+  assert(!SharedSerialGCVirtualSpace, "unexpected invocation of shrink");
   assert_correct_size_change_locking();
 
   size_t size = os::align_down_vm_page_size(bytes);
@@ -140,7 +144,7 @@ void TenuredGeneration::shrink(size_t bytes) {
                       name(), old_mem_size/K, new_mem_size/K);
 }
 
-void TenuredGeneration::compute_new_size_inner() {
+size_t TenuredGeneration::compute_new_size() {
   assert(_shrink_factor <= 100, "invalid shrink factor");
   size_t current_shrink_factor = _shrink_factor;
   if (ShrinkHeapInSteps) {
@@ -178,17 +182,7 @@ void TenuredGeneration::compute_new_size_inner() {
     log_trace(gc, heap)("     free_percentage: %6.2f", free_percentage);
 
   if (capacity_after_gc < minimum_desired_capacity) {
-    // If we have less free space than we want then expand
-    size_t expand_bytes = minimum_desired_capacity - capacity_after_gc;
-    // Don't expand unless it's significant
-    if (expand_bytes >= _min_heap_delta_bytes) {
-      expand(expand_bytes, 0); // safe if expansion fails
-    }
-    log_trace(gc, heap)("    expanding:  minimum_desired_capacity: %6.1fK  expand_bytes: %6.1fK  _min_heap_delta_bytes: %6.1fK",
-                  minimum_desired_capacity / (double) K,
-                  expand_bytes / (double) K,
-                  _min_heap_delta_bytes / (double) K);
-    return;
+    return minimum_desired_capacity;
   }
 
   // No expansion, now see if we want to shrink
@@ -256,9 +250,11 @@ void TenuredGeneration::compute_new_size_inner() {
                         shrink_bytes / (double) K);
   }
   // Don't shrink unless it's significant
-  if (shrink_bytes >= _min_heap_delta_bytes) {
-    shrink(shrink_bytes);
+  if (shrink_bytes < _min_heap_delta_bytes) {
+    shrink_bytes = 0;
   }
+
+  return capacity_after_gc - shrink_bytes;
 }
 
 HeapWord* TenuredGeneration::block_start(const void* addr) const {
@@ -311,10 +307,17 @@ TenuredGeneration::TenuredGeneration(ReservedSpace rs,
   _min_heap_delta_bytes = MinHeapDeltaBytes;
   _capacity_at_prologue = initial_byte_size;
   _used_at_prologue = 0;
-  HeapWord* bottom = (HeapWord*) _virtual_space.low();
-  HeapWord* end    = (HeapWord*) _virtual_space.high();
   _the_space  = new ContiguousSpace();
-  _the_space->initialize(MemRegion(bottom, end), SpaceDecorator::Clear, SpaceDecorator::Mangle);
+
+  if (SharedSerialGCVirtualSpace) {
+    SerialHeap* gch = SerialHeap::heap();
+    _the_space->initialize(gch->shared_virtual_space()->tenured_region(), SpaceDecorator::Clear, SpaceDecorator::Mangle);
+  } else {
+    HeapWord* bottom = (HeapWord*) _virtual_space.low();
+    HeapWord* end    = (HeapWord*) _virtual_space.high();
+    _the_space->initialize(MemRegion(bottom, end), SpaceDecorator::Clear, SpaceDecorator::Mangle);
+  }
+
   // If we don't shrink the heap in steps, '_shrink_factor' is always 100%.
   _shrink_factor = ShrinkHeapInSteps ? 0 : 100;
   _capacity_at_prologue = 0;
@@ -340,14 +343,31 @@ void TenuredGeneration::gc_prologue() {
   _used_at_prologue = used();
 }
 
-void TenuredGeneration::compute_new_size() {
+void TenuredGeneration::resize() {
+  assert(!SharedSerialGCVirtualSpace, "unexpected invocation of resize");
   assert_locked_or_safepoint(Heap_lock);
 
   // Compute some numbers about the state of the heap.
   const size_t used_after_gc = used();
   const size_t capacity_after_gc = capacity();
 
-  compute_new_size_inner();
+  size_t new_size = compute_new_size();
+
+  if (capacity_after_gc < new_size) {
+      // If we have less free space than we want then expand
+    size_t expand_bytes = new_size - capacity_after_gc;
+    // Don't expand unless it's significant
+    if (expand_bytes >= _min_heap_delta_bytes) {
+      expand(expand_bytes, 0); // safe if expansion fails
+    }
+    log_trace(gc, heap)("    expanding:  minimum_desired_capacity: %6.1fK  expand_bytes: %6.1fK  _min_heap_delta_bytes: %6.1fK",
+                  new_size / (double) K,
+                  expand_bytes / (double) K,
+                  _min_heap_delta_bytes / (double) K);
+  } else if (capacity_after_gc > new_size) {
+    size_t shrink_bytes = capacity_after_gc - new_size;
+    shrink(shrink_bytes);
+  }
 
   assert(used() == used_after_gc && used_after_gc <= capacity(),
          "used: %zu used_after_gc: %zu"
@@ -443,10 +463,26 @@ void TenuredGeneration::print_on(outputStream* st)  const {
 
   st->print(" total %zuK, used %zuK",
             capacity()/K, used()/K);
+
+  char* low_boundary;
+  char* high;
+  char* high_boundary;
+
+  if (!SharedSerialGCVirtualSpace) {
+    low_boundary = _virtual_space.low_boundary();
+    high = _virtual_space.high();
+    high_boundary = _virtual_space.high_boundary();
+  } else {
+    MemRegion tenured_region = SerialHeap::heap()->shared_virtual_space()->tenured_region();
+    low_boundary = (char*)tenured_region.start();
+    high_boundary = (char*)tenured_region.end();
+    high = high_boundary;
+  }
+
   st->print_cr(" [" PTR_FORMAT ", " PTR_FORMAT ", " PTR_FORMAT ")",
-               p2i(_virtual_space.low_boundary()),
-               p2i(_virtual_space.high()),
-               p2i(_virtual_space.high_boundary()));
+    p2i(low_boundary),
+    p2i(high),
+    p2i(high_boundary));
 
   st->print("   the");
   _the_space->print_on(st);

--- a/src/hotspot/share/gc/serial/tenuredGeneration.hpp
+++ b/src/hotspot/share/gc/serial/tenuredGeneration.hpp
@@ -82,10 +82,9 @@ class TenuredGeneration: public Generation {
   // Shrink generation with specified size
   void shrink(size_t bytes);
 
-  void compute_new_size_inner();
-
 public:
-  void compute_new_size();
+  size_t compute_new_size();
+  void resize();
 
   ContiguousSpace* space() const { return _the_space; }
 

--- a/src/hotspot/share/gc/shared/cardTable.cpp
+++ b/src/hotspot/share/gc/shared/cardTable.cpp
@@ -275,10 +275,10 @@ void CardTable::print_on(outputStream* st) const {
                p2i(_byte_map), p2i(_byte_map + _byte_map_size), p2i(_byte_map_base));
 }
 
-MemRegion CardTable::committed_card_table_mem_for_shared_virtual_space_region(const MemRegion mr) const {
+MemRegion CardTable::card_table_mem_for_shared_virtual_space_region(const MemRegion mr) const {
   HeapWord* addr_l = (HeapWord*)byte_for(mr.start());
 
-  log_trace(gc, barrier)("CardTable::committed_card_table_mem_for_shared_virtual_space_region: ");
+  log_trace(gc, barrier)("CardTable::card_table_mem_for_shared_virtual_space_region: ");
   log_trace(gc, barrier)("    mr.start():                    " PTR_FORMAT "  mr.last(): " PTR_FORMAT,
                          p2i(mr.start()), p2i(mr.last()));
   log_trace(gc, barrier)("    byte_for(mr.start()):          " PTR_FORMAT, p2i(addr_l));
@@ -347,10 +347,10 @@ void CardTable::resize_covered_region_in_shared_virtual_space(MemRegion new_heap
 #endif
 
   MemRegion prev_heap_region = _covered[0]._union(_covered[1]);
-  MemRegion prev_committed_card_table_mem = committed_card_table_mem_for_shared_virtual_space_region(prev_heap_region);
+  MemRegion prev_committed_card_table_mem = card_table_mem_for_shared_virtual_space_region(prev_heap_region);
 
   MemRegion heap_region = new_heap_region0._union(new_heap_region1);
-  MemRegion card_table_mem_to_commit = committed_card_table_mem_for_shared_virtual_space_region(heap_region);
+  MemRegion card_table_mem_to_commit = card_table_mem_for_shared_virtual_space_region(heap_region);
   assert(card_table_mem_to_commit.start() == prev_committed_card_table_mem.start(), "start of committed card table memory must not change");
 
 #ifdef ASSERT
@@ -405,9 +405,9 @@ void CardTable::resize_covered_region_in_shared_virtual_space(MemRegion new_heap
     log_trace(gc, barrier)("Committed card table region unchanged");
   }
 
-  MemRegion prev_committed_card_table_mem_for_tenured = committed_card_table_mem_for_shared_virtual_space_region(_covered[tenured_idx]);
-  MemRegion committed_card_table_mem_for_tenured = committed_card_table_mem_for_shared_virtual_space_region(new_heap_region0);
-  MemRegion committed_card_table_mem_for_young = committed_card_table_mem_for_shared_virtual_space_region(new_heap_region1);
+  MemRegion prev_committed_card_table_mem_for_tenured = card_table_mem_for_shared_virtual_space_region(_covered[tenured_idx]);
+  MemRegion committed_card_table_mem_for_tenured = card_table_mem_for_shared_virtual_space_region(new_heap_region0);
+  MemRegion committed_card_table_mem_for_young = card_table_mem_for_shared_virtual_space_region(new_heap_region1);
 
   _covered[tenured_idx] = new_heap_region0;
   _covered[young_idx] = new_heap_region1;

--- a/src/hotspot/share/gc/shared/cardTable.cpp
+++ b/src/hotspot/share/gc/shared/cardTable.cpp
@@ -278,14 +278,14 @@ void CardTable::print_on(outputStream* st) const {
 MemRegion CardTable::committed_for_region_in_shared_virtual_space(const MemRegion mr) const {
   HeapWord* addr_l = (HeapWord*)byte_for(mr.start());
 
-  log_debug(gc, barrier)("CardTable::committed_for_region_in_shared_virtual_space: ");
-  log_debug(gc, barrier)("    mr.start():                          " PTR_FORMAT "  mr.last():                          " PTR_FORMAT,
+  log_trace(gc, barrier)("CardTable::committed_for_region_in_shared_virtual_space: ");
+  log_trace(gc, barrier)("    mr.start():                          " PTR_FORMAT "  mr.last():                          " PTR_FORMAT,
                          p2i(mr.start()), p2i(mr.last()));
-  log_debug(gc, barrier)("    byte_for(mr.start()):                " PTR_FORMAT, p2i(addr_l));
+  log_trace(gc, barrier)("    byte_for(mr.start()):                " PTR_FORMAT, p2i(addr_l));
 
   if (mr.start() == _covered[0].start()) {
     addr_l = (HeapWord*)align_down(addr_l, _page_size);
-    log_debug(gc, barrier)("    aligned byte_for(mr.start()):        " PTR_FORMAT, p2i(addr_l));
+    log_trace(gc, barrier)("    aligned byte_for(mr.start()):        " PTR_FORMAT, p2i(addr_l));
   }
 
   HeapWord* addr_r;
@@ -293,11 +293,11 @@ MemRegion CardTable::committed_for_region_in_shared_virtual_space(const MemRegio
     addr_r = addr_l;
   } else {
     addr_r = (HeapWord*)byte_after(mr.last());
-    log_debug(gc, barrier)("    byte_after(mr.last()):               " PTR_FORMAT, p2i(addr_r));
+    log_trace(gc, barrier)("    byte_after(mr.last()):               " PTR_FORMAT, p2i(addr_r));
 
     if (mr.start() == _covered[1].start()) {
       addr_r = (HeapWord*)align_up(addr_r, _page_size);
-      log_debug(gc, barrier)("    aligned byte_after(mr.last()):       " PTR_FORMAT, p2i(addr_r));
+      log_trace(gc, barrier)("    aligned byte_after(mr.last()):       " PTR_FORMAT, p2i(addr_r));
     }
   }
 

--- a/src/hotspot/share/gc/shared/cardTable.cpp
+++ b/src/hotspot/share/gc/shared/cardTable.cpp
@@ -279,13 +279,13 @@ MemRegion CardTable::committed_card_table_mem_for_shared_virtual_space_region(co
   HeapWord* addr_l = (HeapWord*)byte_for(mr.start());
 
   log_trace(gc, barrier)("CardTable::committed_card_table_mem_for_shared_virtual_space_region: ");
-  log_trace(gc, barrier)("    mr.start():                          " PTR_FORMAT "  mr.last():                          " PTR_FORMAT,
+  log_trace(gc, barrier)("    mr.start():                    " PTR_FORMAT "  mr.last(): " PTR_FORMAT,
                          p2i(mr.start()), p2i(mr.last()));
-  log_trace(gc, barrier)("    byte_for(mr.start()):                " PTR_FORMAT, p2i(addr_l));
+  log_trace(gc, barrier)("    byte_for(mr.start()):          " PTR_FORMAT, p2i(addr_l));
 
   if (mr.start() == _covered[0].start()) {
     addr_l = (HeapWord*)align_down(addr_l, _page_size);
-    log_trace(gc, barrier)("    aligned byte_for(mr.start()):        " PTR_FORMAT, p2i(addr_l));
+    log_trace(gc, barrier)("    aligned byte_for(mr.start()):  " PTR_FORMAT, p2i(addr_l));
   }
 
   HeapWord* addr_r;
@@ -293,11 +293,11 @@ MemRegion CardTable::committed_card_table_mem_for_shared_virtual_space_region(co
     addr_r = addr_l;
   } else {
     addr_r = (HeapWord*)byte_after(mr.last());
-    log_trace(gc, barrier)("    byte_after(mr.last()):               " PTR_FORMAT, p2i(addr_r));
+    log_trace(gc, barrier)("    byte_after(mr.last()):         " PTR_FORMAT, p2i(addr_r));
 
     if (mr.start() == _covered[1].start()) {
       addr_r = (HeapWord*)align_up(addr_r, _page_size);
-      log_trace(gc, barrier)("    aligned byte_after(mr.last()):       " PTR_FORMAT, p2i(addr_r));
+      log_trace(gc, barrier)("    aligned byte_after(mr.last()): " PTR_FORMAT, p2i(addr_r));
     }
   }
 

--- a/src/hotspot/share/gc/shared/cardTable.cpp
+++ b/src/hotspot/share/gc/shared/cardTable.cpp
@@ -437,8 +437,15 @@ void CardTable::resize_covered_region_in_shared_virtual_space(MemRegion new_heap
   }
 #endif
 
-  assert(committed_card_table_mem_for_tenured.last() < committed_card_table_mem_for_young.start(), "last word of tenured must be less than first word of young gen");
-  assert(committed_card_table_mem_for_young.last() <= card_table_mem_to_commit.last(), "last word of young gen must be in committed card table memory");
+  assert(committed_card_table_mem_for_tenured.last() < committed_card_table_mem_for_young.start(),
+         "last word of tenured (" PTR_FORMAT ") must be less than first word of young gen (" PTR_FORMAT ")",
+         p2i(committed_card_table_mem_for_tenured.last()),
+         p2i(committed_card_table_mem_for_young.start()));
+
+  assert(committed_card_table_mem_for_young.last() <= card_table_mem_to_commit.last(),
+         "last word of young gen (" PTR_FORMAT ") must be in committed card table memory (" PTR_FORMAT ")",
+         p2i(committed_card_table_mem_for_young.last()),
+         p2i(card_table_mem_to_commit.last()));
 
   if (committed_card_table_mem_for_tenured.word_size() > prev_committed_card_table_mem_for_tenured.word_size()) {
     // Write the clean_card to the entire delta region

--- a/src/hotspot/share/gc/shared/cardTable.cpp
+++ b/src/hotspot/share/gc/shared/cardTable.cpp
@@ -324,10 +324,10 @@ void CardTable::resize_covered_region_in_shared_virtual_space(MemRegion new_heap
   assert(_covered[0].start() != nullptr, "_covered[0].start() must not be null");
   assert(_covered[1].start() == _covered[0].end(), "_covered[1] must start at the end of _covered[0]");
 
-  const int old_gen_idx = 0, young_gen_idx = 1;
+  const int tenured_idx = 0, young_idx = 1;
 
   // We don't allow changes to the start of region0, only the end.
-  assert(_covered[old_gen_idx].start() == new_heap_region0.start(), "start of region0 must not change");
+  assert(_covered[tenured_idx].start() == new_heap_region0.start(), "start of region0 must not change");
 
   assert(new_heap_region1.start() == new_heap_region0.end(), "start of region1 must start at the end of region0");
 
@@ -405,12 +405,12 @@ void CardTable::resize_covered_region_in_shared_virtual_space(MemRegion new_heap
     log_trace(gc, barrier)("Committed card table region unchanged");
   }
 
-  MemRegion prev_committed_tenured = committed_for_region_in_shared_virtual_space(_covered[old_gen_idx]);
+  MemRegion prev_committed_tenured = committed_for_region_in_shared_virtual_space(_covered[tenured_idx]);
   MemRegion committed_tenured = committed_for_region_in_shared_virtual_space(new_heap_region0);
   MemRegion committed_young = committed_for_region_in_shared_virtual_space(new_heap_region1);
 
-  _covered[old_gen_idx] = new_heap_region0;
-  _covered[young_gen_idx] = new_heap_region1;
+  _covered[tenured_idx] = new_heap_region0;
+  _covered[young_idx] = new_heap_region1;
 
 #ifdef ASSERT
   log_trace(gc, barrier)("CardTable::resize_covered_region_shared_virtual_space: ");
@@ -445,13 +445,13 @@ void CardTable::resize_covered_region_in_shared_virtual_space(MemRegion new_heap
 
     log_trace(gc, barrier)("CardTable expanding covered region for tenured: ");
     log_trace(gc, barrier)("    _covered[%d].start():          " PTR_FORMAT "  _covered[%d].last():             " PTR_FORMAT,
-                           old_gen_idx, p2i(_covered[old_gen_idx].start()),
-                           old_gen_idx, p2i(_covered[old_gen_idx].last()));
+                           tenured_idx, p2i(_covered[tenured_idx].start()),
+                           tenured_idx, p2i(_covered[tenured_idx].last()));
     log_trace(gc, barrier)("    committed_tenured_start:      " PTR_FORMAT "  committed_tenured_last:         " PTR_FORMAT,
                            p2i(committed_tenured.start()), p2i(committed_tenured.last()));
     log_trace(gc, barrier)("    byte_for(_covered[%d].start):  " PTR_FORMAT "  byte_for(_covered[%d].last):     " PTR_FORMAT,
-                           old_gen_idx, p2i(byte_for(_covered[old_gen_idx].start())),
-                           old_gen_idx, p2i(byte_for(_covered[old_gen_idx].last())));
+                           tenured_idx, p2i(byte_for(_covered[tenured_idx].start())),
+                           tenured_idx, p2i(byte_for(_covered[tenured_idx].last())));
     log_trace(gc, barrier)("    addr_for(start):              " PTR_FORMAT "  addr_for(last):     " PTR_FORMAT,
                            p2i(addr_for((CardValue*) committed_tenured.start())),  p2i(addr_for((CardValue*) committed_tenured.last())));
 
@@ -487,7 +487,7 @@ void CardTable::resize_covered_region_in_shared_virtual_space(MemRegion new_heap
   // Touch the last card of the covered region to show that it
   // is committed (or SEGV).
   if (is_init_completed()) {
-    (void) (*(volatile CardValue*)byte_for(_covered[young_gen_idx].last()));
+    (void) (*(volatile CardValue*)byte_for(_covered[young_idx].last()));
   }
 #endif
 }

--- a/src/hotspot/share/gc/shared/cardTable.cpp
+++ b/src/hotspot/share/gc/shared/cardTable.cpp
@@ -275,10 +275,10 @@ void CardTable::print_on(outputStream* st) const {
                p2i(_byte_map), p2i(_byte_map + _byte_map_size), p2i(_byte_map_base));
 }
 
-MemRegion CardTable::committed_for_region_in_shared_virtual_space(const MemRegion mr) const {
+MemRegion CardTable::committed_card_table_mem_for_shared_virtual_space_region(const MemRegion mr) const {
   HeapWord* addr_l = (HeapWord*)byte_for(mr.start());
 
-  log_trace(gc, barrier)("CardTable::committed_for_region_in_shared_virtual_space: ");
+  log_trace(gc, barrier)("CardTable::committed_card_table_mem_for_shared_virtual_space_region: ");
   log_trace(gc, barrier)("    mr.start():                          " PTR_FORMAT "  mr.last():                          " PTR_FORMAT,
                          p2i(mr.start()), p2i(mr.last()));
   log_trace(gc, barrier)("    byte_for(mr.start()):                " PTR_FORMAT, p2i(addr_l));
@@ -347,10 +347,10 @@ void CardTable::resize_covered_region_in_shared_virtual_space(MemRegion new_heap
 #endif
 
   MemRegion prev_heap_region = _covered[0]._union(_covered[1]);
-  MemRegion prev_committed_card_table_mem = committed_for_region_in_shared_virtual_space(prev_heap_region);
+  MemRegion prev_committed_card_table_mem = committed_card_table_mem_for_shared_virtual_space_region(prev_heap_region);
 
   MemRegion heap_region = new_heap_region0._union(new_heap_region1);
-  MemRegion card_table_mem_to_commit = committed_for_region_in_shared_virtual_space(heap_region);
+  MemRegion card_table_mem_to_commit = committed_card_table_mem_for_shared_virtual_space_region(heap_region);
   assert(card_table_mem_to_commit.start() == prev_committed_card_table_mem.start(), "start of committed card table memory must not change");
 
 #ifdef ASSERT
@@ -405,9 +405,9 @@ void CardTable::resize_covered_region_in_shared_virtual_space(MemRegion new_heap
     log_trace(gc, barrier)("Committed card table region unchanged");
   }
 
-  MemRegion prev_committed_card_table_mem_for_tenured = committed_for_region_in_shared_virtual_space(_covered[tenured_idx]);
-  MemRegion committed_card_table_mem_for_tenured = committed_for_region_in_shared_virtual_space(new_heap_region0);
-  MemRegion committed_card_table_mem_for_young = committed_for_region_in_shared_virtual_space(new_heap_region1);
+  MemRegion prev_committed_card_table_mem_for_tenured = committed_card_table_mem_for_shared_virtual_space_region(_covered[tenured_idx]);
+  MemRegion committed_card_table_mem_for_tenured = committed_card_table_mem_for_shared_virtual_space_region(new_heap_region0);
+  MemRegion committed_card_table_mem_for_young = committed_card_table_mem_for_shared_virtual_space_region(new_heap_region1);
 
   _covered[tenured_idx] = new_heap_region0;
   _covered[young_idx] = new_heap_region1;

--- a/src/hotspot/share/gc/shared/cardTable.cpp
+++ b/src/hotspot/share/gc/shared/cardTable.cpp
@@ -329,7 +329,7 @@ void CardTable::resize_covered_region_in_shared_virtual_space(MemRegion new_heap
   // We don't allow changes to the start of region0, only the end.
   assert(_covered[tenured_idx].start() == new_heap_region0.start(), "start of region0 must not change");
 
-  assert(new_heap_region1.start() == new_heap_region0.end(), "start of region1 must start at the end of region0");
+  assert(new_heap_region1.start() == new_heap_region0.end(), "region1 must start at the end of region0");
 
 #ifdef ASSERT
   log_trace(gc, barrier)("CardTable resizing covered region in shared virtual space: ");

--- a/src/hotspot/share/gc/shared/cardTable.cpp
+++ b/src/hotspot/share/gc/shared/cardTable.cpp
@@ -274,3 +274,220 @@ void CardTable::print_on(outputStream* st) const {
   st->print_cr("Card table byte_map: [" PTR_FORMAT "," PTR_FORMAT "] _byte_map_base: " PTR_FORMAT,
                p2i(_byte_map), p2i(_byte_map + _byte_map_size), p2i(_byte_map_base));
 }
+
+MemRegion CardTable::committed_for_region_in_shared_virtual_space(const MemRegion mr) const {
+  HeapWord* addr_l = (HeapWord*)byte_for(mr.start());
+
+  log_debug(gc, barrier)("CardTable::committed_for_region_in_shared_virtual_space: ");
+  log_debug(gc, barrier)("    mr.start():                          " PTR_FORMAT "  mr.last():                          " PTR_FORMAT,
+                         p2i(mr.start()), p2i(mr.last()));
+  log_debug(gc, barrier)("    byte_for(mr.start()):                " PTR_FORMAT, p2i(addr_l));
+
+  if (mr.start() == _covered[0].start()) {
+    addr_l = (HeapWord*)align_down(addr_l, _page_size);
+    log_debug(gc, barrier)("    aligned byte_for(mr.start()):        " PTR_FORMAT, p2i(addr_l));
+  }
+
+  HeapWord* addr_r;
+  if (mr.is_empty()) {
+    addr_r = addr_l;
+  } else {
+    addr_r = (HeapWord*)byte_after(mr.last());
+    log_debug(gc, barrier)("    byte_after(mr.last()):               " PTR_FORMAT, p2i(addr_r));
+
+    if (mr.start() == _covered[1].start()) {
+      addr_r = (HeapWord*)align_up(addr_r, _page_size);
+      log_debug(gc, barrier)("    aligned byte_after(mr.last()):       " PTR_FORMAT, p2i(addr_r));
+    }
+  }
+
+  return MemRegion(addr_l, addr_r);
+}
+
+void CardTable::resize_covered_region_in_shared_virtual_space(MemRegion new_region0, MemRegion new_region1) {
+#ifdef ASSERT
+  log_trace(gc, barrier)("CardTable::resize_covered_region_shared_virtual_space: ");
+  log_trace(gc, barrier)("   _whole_heap.start(): " PTR_FORMAT " _whole_heap.end(): " PTR_FORMAT,
+                         p2i(_whole_heap.start()), p2i(_whole_heap.end()));
+  log_trace(gc, barrier)("   new_region0.start(): " PTR_FORMAT " new_region0.end(): " PTR_FORMAT,
+                         p2i(new_region0.start()), p2i(new_region0.end()));
+  log_trace(gc, barrier)("   new_region1.start(): " PTR_FORMAT " new_region1.end(): " PTR_FORMAT,
+                         p2i(new_region1.start()), p2i(new_region1.end()));
+#endif
+
+  assert(UseSerialGC, "only the serial collector uses this method");
+  assert(SharedSerialGCVirtualSpace, "the SharedSerialGCVirtualSpace flag must be enabled");
+  assert(_whole_heap.contains(new_region0),
+         "attempt to cover area not in reserved area (region 0)");
+  assert(_whole_heap.contains(new_region1),
+         "attempt to cover area not in reserved area (region 1)");
+  assert(_covered[0].start() != nullptr, "_covered[0].start() must not be null");
+  assert(_covered[1].start() == _covered[0].end(), "_covered[1] must start at the end of _covered[0]");
+
+  const int old_gen_idx = 0, young_gen_idx = 1;
+
+  // We don't allow changes to the start of region0, only the end.
+  assert(_covered[old_gen_idx].start() == new_region0.start(), "start of region0 must not change");
+
+  assert(new_region1.start() == new_region0.end(), "start of region1 must start at the end of region0");
+
+#ifdef ASSERT
+  log_trace(gc, barrier)("CardTable resizing covered region in shared virtual space: ");
+  for (int idx=0; idx < 2; idx++) {
+    log_trace(gc, barrier)("   Before _covered[%d].start(): " PTR_FORMAT
+                           " _covered[%d].end(): " PTR_FORMAT,
+                           idx, p2i(_covered[idx].start()),
+                           idx, p2i(_covered[idx].end()));
+
+    log_trace(gc, barrier)("   After  _covered[%d].start(): " PTR_FORMAT
+                           " _covered[%d].end(): " PTR_FORMAT,
+                           idx, p2i(idx == 0 ? new_region0.start() : new_region1.start()),
+                           idx, p2i(idx == 0 ? new_region0.end() : new_region1.end()));
+  }
+#endif
+
+  MemRegion prev_combined_region = _covered[0]._union(_covered[1]);
+  MemRegion prev_committed = committed_for_region_in_shared_virtual_space(prev_combined_region);
+
+  MemRegion combined_region = new_region0._union(new_region1);
+  MemRegion new_committed = committed_for_region_in_shared_virtual_space(combined_region);
+  assert(new_committed.start() == prev_committed.start(), "start of committed card table memory must not change");
+
+#ifdef ASSERT
+  log_trace(gc, barrier)("CardTable computed combined region: ");
+  log_trace(gc, barrier)("    prev_combined_region.start(): " PTR_FORMAT "  prev_combined_region.end(): " PTR_FORMAT,
+                         p2i(prev_combined_region.start()), p2i(prev_combined_region.end()));
+  log_trace(gc, barrier)("    combined_region.start():      " PTR_FORMAT "  combined_region.end(): " PTR_FORMAT,
+                         p2i(combined_region.start()), p2i(combined_region.end()));
+#endif
+
+  // Adjust the size of the committed space
+  if (new_committed.word_size() > prev_committed.word_size()) {
+    // Expand.
+
+    MemRegion delta = MemRegion(prev_committed.end(),
+                                new_committed.word_size() - prev_committed.word_size());
+
+    size_t delta_byte_size = delta.byte_size();
+
+    log_trace(gc, barrier)("CardTable resizing covered region, expanding committed card table region by %zu bytes", delta_byte_size);
+    log_trace(gc, barrier)("    new_committed.start(): " PTR_FORMAT "  new_committed.last(): " PTR_FORMAT,
+                           p2i(new_committed.start()), p2i(new_committed.last()));
+    log_trace(gc, barrier)("    addr_for(start):       " PTR_FORMAT "  addr_for(last):       " PTR_FORMAT,
+                           p2i(addr_for((CardValue*) new_committed.start())),  p2i(addr_for((CardValue*) new_committed.last())));
+    log_trace(gc, barrier)("    commit delta start:    " PTR_FORMAT "  commit delta last:    " PTR_FORMAT,
+                           p2i(delta.start()), p2i(delta.last()));
+
+    os::commit_memory_or_exit((char*)delta.start(),
+                              delta_byte_size,
+                              _page_size,
+                              !ExecMem,
+                              "card table expansion");
+
+    memset(delta.start(), clean_card, delta.byte_size());
+  } else if (new_committed.word_size() < prev_committed.word_size()) {
+    // Shrink.
+    MemRegion delta = MemRegion(new_committed.end(),
+                                prev_committed.word_size() - new_committed.word_size());
+
+    log_trace(gc, barrier)("CardTable resizing covered region, shrinking committed card table region: ");
+    log_trace(gc, barrier)("    new_committed_start: " PTR_FORMAT "  new_committed_last: " PTR_FORMAT,
+                           p2i(new_committed.start()), p2i(new_committed.last()));
+    log_trace(gc, barrier)("    addr_for(start):     " PTR_FORMAT "  addr_for(last):     " PTR_FORMAT,
+                           p2i(addr_for((CardValue*) new_committed.start())),  p2i(addr_for((CardValue*) new_committed.last())));
+    log_trace(gc, barrier)("    uncommit_start:      " PTR_FORMAT "  uncommit_last:      " PTR_FORMAT,
+                           p2i(delta.start()), p2i(delta.last()));
+
+    bool res = os::uncommit_memory((char*)delta.start(),
+                                   delta.byte_size());
+    assert(res, "uncommit should succeed");
+  } else {
+    log_trace(gc, barrier)("Committed card table region unchanged");
+  }
+
+  MemRegion prev_committed_tenured = committed_for_region_in_shared_virtual_space(_covered[old_gen_idx]);
+  MemRegion committed_tenured = committed_for_region_in_shared_virtual_space(new_region0);
+  MemRegion committed_young = committed_for_region_in_shared_virtual_space(new_region1);
+
+  _covered[old_gen_idx] = new_region0;
+  _covered[young_gen_idx] = new_region1;
+
+#ifdef ASSERT
+  log_trace(gc, barrier)("CardTable::resize_covered_region_shared_virtual_space: ");
+  log_trace(gc, barrier)("    prev_committed.start():              " PTR_FORMAT "  prev_committed.last():              " PTR_FORMAT,
+                         p2i(prev_committed.start()), p2i(prev_committed.last()));
+  log_trace(gc, barrier)("    new_committed_start:                 " PTR_FORMAT "  new_committed_last:                 " PTR_FORMAT,
+                         p2i(new_committed.start()), p2i(new_committed.last()));
+  log_trace(gc, barrier)("    committed_tenured.start():           " PTR_FORMAT "  committed_tenured.last():           " PTR_FORMAT,
+                         p2i(committed_tenured.start()), p2i(committed_tenured.last()));
+  log_trace(gc, barrier)("    committed_young.start():             " PTR_FORMAT "  committed_young.last():             " PTR_FORMAT,
+                         p2i(committed_young.start()), p2i(committed_young.last()));
+  log_trace(gc, barrier)("    addr_for(committed_tenured.start()): " PTR_FORMAT "  addr_for(committed_tenured.last()): " PTR_FORMAT,
+                         p2i(addr_for((CardValue*) committed_tenured.start())),  p2i(addr_for((CardValue*) committed_tenured.last())));
+  log_trace(gc, barrier)("    addr_for(committed_young.start()):   " PTR_FORMAT "  addr_for(committed_young.last()):   " PTR_FORMAT,
+                         p2i(addr_for((CardValue*) committed_young.start())),  p2i(addr_for((CardValue*) committed_young.last())));
+
+  for (int idx=0; idx < 2; idx++) {
+    log_trace(gc, barrier)("    _covered[%d].start():           " PTR_FORMAT "  _covered[%d].last(): " PTR_FORMAT,
+                            idx, p2i(_covered[idx].start()),
+                            idx, p2i(_covered[idx].last()));
+    log_trace(gc, barrier)("    byte_for(_covered[%d].start()): " PTR_FORMAT "  byte_for(_covered[%d].last()): " PTR_FORMAT,
+                           idx, p2i(byte_for(_covered[idx].start())),
+                           idx, p2i(byte_for(_covered[idx].last())));
+  }
+#endif
+
+  assert(committed_tenured.last() < committed_young.start(), "last word of tenured must be less than first word of young gen");
+  assert(committed_young.last() <= new_committed.last(), "last word of young gen must be in committed card table memory");
+
+  if (committed_tenured.word_size() > prev_committed_tenured.word_size()) {
+    // Write the clean_card to the entire delta region
+
+    log_trace(gc, barrier)("CardTable expanding covered region for tenured: ");
+    log_trace(gc, barrier)("    _covered[%d].start():          " PTR_FORMAT "  _covered[%d].last():             " PTR_FORMAT,
+                           old_gen_idx, p2i(_covered[old_gen_idx].start()),
+                           old_gen_idx, p2i(_covered[old_gen_idx].last()));
+    log_trace(gc, barrier)("    committed_tenured_start:      " PTR_FORMAT "  committed_tenured_last:         " PTR_FORMAT,
+                           p2i(committed_tenured.start()), p2i(committed_tenured.last()));
+    log_trace(gc, barrier)("    byte_for(_covered[%d].start):  " PTR_FORMAT "  byte_for(_covered[%d].last):     " PTR_FORMAT,
+                           old_gen_idx, p2i(byte_for(_covered[old_gen_idx].start())),
+                           old_gen_idx, p2i(byte_for(_covered[old_gen_idx].last())));
+    log_trace(gc, barrier)("    addr_for(start):              " PTR_FORMAT "  addr_for(last):     " PTR_FORMAT,
+                           p2i(addr_for((CardValue*) committed_tenured.start())),  p2i(addr_for((CardValue*) committed_tenured.last())));
+
+    MemRegion tenured_delta = MemRegion(prev_committed_tenured.end(),
+                                        committed_tenured.word_size() - prev_committed_tenured.word_size());
+
+    memset(tenured_delta.start(), clean_card, tenured_delta.byte_size());
+
+    // If the end of the committed_young region has shrunk, there is nothing else to do.
+    // If it has expanded, then the expansion of the committed card table memory has already
+    // written the clean_card to the expanded region. Nothing else needs to be done in
+    // this case as well.
+  } else if (committed_tenured.word_size() < prev_committed_tenured.word_size()) {
+    // Shrink.
+
+    MemRegion tenured_delta;
+    if (prev_committed_tenured.end() > new_committed.end()) {
+      // Ensure the delta is in the current heap!
+      tenured_delta = MemRegion(committed_tenured.end(), new_committed.end());
+    } else {
+      tenured_delta = MemRegion(committed_tenured.end(),
+                                          prev_committed_tenured.word_size() - committed_tenured.word_size());
+    }
+
+    log_trace(gc, barrier)("CardTable shrinking covered region for tenured, writing clean_card to region: ");
+    log_trace(gc, barrier)("    tenured_delta.start():        " PTR_FORMAT "  tenured_delta.last():           " PTR_FORMAT,
+                           p2i(tenured_delta.start()), p2i(tenured_delta.last()));
+
+    memset(tenured_delta.start(), clean_card, tenured_delta.byte_size());
+  }
+
+#ifdef ASSERT
+  // Touch the last card of the covered region to show that it
+  // is committed (or SEGV).
+  if (is_init_completed()) {
+    (void) (*(volatile CardValue*)byte_for(_covered[young_gen_idx].last()));
+  }
+#endif
+}

--- a/src/hotspot/share/gc/shared/cardTable.hpp
+++ b/src/hotspot/share/gc/shared/cardTable.hpp
@@ -84,7 +84,7 @@ private:
   void initialize_covered_region(void* region0_start, void* region1_start);
 
   MemRegion committed_for(const MemRegion mr) const;
-  MemRegion committed_card_table_mem_for_shared_virtual_space_region(const MemRegion mr) const;
+  MemRegion card_table_mem_for_shared_virtual_space_region(const MemRegion mr) const;
 public:
   CardTable(MemRegion whole_heap);
   virtual ~CardTable() = default;

--- a/src/hotspot/share/gc/shared/cardTable.hpp
+++ b/src/hotspot/share/gc/shared/cardTable.hpp
@@ -84,7 +84,7 @@ private:
   void initialize_covered_region(void* region0_start, void* region1_start);
 
   MemRegion committed_for(const MemRegion mr) const;
-  MemRegion committed_for_region_in_shared_virtual_space(const MemRegion mr) const;
+  MemRegion committed_card_table_mem_for_shared_virtual_space_region(const MemRegion mr) const;
 public:
   CardTable(MemRegion whole_heap);
   virtual ~CardTable() = default;

--- a/src/hotspot/share/gc/shared/cardTable.hpp
+++ b/src/hotspot/share/gc/shared/cardTable.hpp
@@ -84,6 +84,7 @@ private:
   void initialize_covered_region(void* region0_start, void* region1_start);
 
   MemRegion committed_for(const MemRegion mr) const;
+  MemRegion committed_for_region_in_shared_virtual_space(const MemRegion mr) const;
 public:
   CardTable(MemRegion whole_heap);
   virtual ~CardTable() = default;
@@ -171,6 +172,9 @@ public:
 
   // Resize one of the regions covered by the remembered set.
   void resize_covered_region(MemRegion new_region);
+
+  // Resize both of the regions covered by the remembered set.
+  void resize_covered_region_in_shared_virtual_space(MemRegion new_region0, MemRegion new_region1);
 
   // *** Card-table-RemSet-specific things.
 

--- a/src/hotspot/share/gc/shared/cardTable.hpp
+++ b/src/hotspot/share/gc/shared/cardTable.hpp
@@ -174,7 +174,7 @@ public:
   void resize_covered_region(MemRegion new_region);
 
   // Resize both of the regions covered by the remembered set.
-  void resize_covered_region_in_shared_virtual_space(MemRegion new_region0, MemRegion new_region1);
+  void resize_covered_region_in_shared_virtual_space(MemRegion new_heap_region0, MemRegion new_heap_region1);
 
   // *** Card-table-RemSet-specific things.
 

--- a/src/hotspot/share/gc/shared/gcArguments.cpp
+++ b/src/hotspot/share/gc/shared/gcArguments.cpp
@@ -128,6 +128,18 @@ void GCArguments::initialize_heap_flags_and_sizes() {
     vm_exit_during_initialization("Incompatible minimum and initial heap sizes specified");
   }
 
+  if (UseSerialGC && SharedSerialGCVirtualSpace) {
+    if (FLAG_IS_CMDLINE(SwapSerialGCGenerations)) {
+      if (SwapSerialGCGenerations) {
+        warning("The SwapSerialGCGenerations command line option does not need to be set when SharedSerialGCVirtualSpace is enabled.");
+      } else {
+        warning("The SwapSerialGCGenerations command line option is forced to true when SharedSerialGCVirtualSpace is enabled.");
+      }
+    }
+
+    FLAG_SET_ERGO(SwapSerialGCGenerations, true);
+  }
+
   // Check heap parameter properties
   if (MaxHeapSize < 2 * M) {
     vm_exit_during_initialization("Too small maximum heap");


### PR DESCRIPTION
JEP draft [JDK-8350152](https://bugs.openjdk.org/browse/JDK-8350152) (Automatic Heap Sizing for the Serial Garbage Collector) proposes dynamically sizing the young generation using GC overhead and adding support for committing and uncommitting memory depending on global memory pressure. The current implementation of the serial collector reserves a single block of memory for the entire heap then splits it into two ReservedSpaces, one for the young generation and another for the tenured generation. Each of the generations then individually commits and uncommits memory.

One drawback of this approach is that with dynamic sizing of the generations, fixed limits of the reserved spaces for each generation will not be compatible with the newly computed region sizes. A possible workaround is to reserve twice the maximum heap size to enable each generation to grow to the dynamically computed sizes. However, there would now be two memory regions to manage when committing and uncommitting memory.

This PR adds an experimental flag, -XX:+SharedSerialGCVirtualSpace, to enable the use of a single reserved space and dynamically partitioning its committed memory into tenured and young regions for the automatic heap sizing scenario.

The new commit not in previous PRs is https://github.com/microsoft/openjdk-jdk/commit/4307f5cc16c116995f494fb34828d0680d677fc9