### PR TITLE
AOTCache mxbean and jcmd AOT.end_training

### DIFF
--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -95,6 +95,7 @@
 #include "runtime/vmOperations.hpp"
 #include "runtime/vmThread.hpp"
 #include "sanitizers/leak.hpp"
+#include "services/management.hpp"
 #include "utilities/align.hpp"
 #include "utilities/bitMap.inline.hpp"
 #include "utilities/defaultStream.hpp"
@@ -113,6 +114,8 @@ intx MetaspaceShared::_relocation_delta;
 char* MetaspaceShared::_requested_base_address;
 Array<Method*>* MetaspaceShared::_archived_method_handle_intrinsics = nullptr;
 bool MetaspaceShared::_use_optimized_module_handling = true;
+int volatile MetaspaceShared::_preimage_static_archive_dumped = 0;
+jlong MetaspaceShared::_preimage_static_archive_recording_duration = 0;
 
 // The CDS archive is divided into the following regions:
 //     rw  - read-write metadata
@@ -920,7 +923,33 @@ void MetaspaceShared::exercise_runtime_cds_code(TRAPS) {
   CDSProtectionDomain::to_file_URL("dummy.jar", Handle(), CHECK);
 }
 
+bool MetaspaceShared::is_recording_preimage_static_archive() {
+  if (CDSConfig::is_dumping_preimage_static_archive()) {
+      return _preimage_static_archive_dumped == 0;
+  }
+  return false;
+}
+
+jlong MetaspaceShared::get_preimage_static_archive_recording_duration() {
+  if (CDSConfig::is_dumping_preimage_static_archive()) {
+    if (_preimage_static_archive_recording_duration == 0) {
+      // The recording has not yet finished so return the current elapsed time.
+      return Management::ticks_to_ms(os::elapsed_counter());
+    }
+    return _preimage_static_archive_recording_duration;
+  }
+  return 0;
+}
+
 void MetaspaceShared::preload_and_dump_impl(StaticArchiveBuilder& builder, TRAPS) {
+  if (CDSConfig::is_dumping_preimage_static_archive()) {
+    if (Atomic::cmpxchg(&_preimage_static_archive_dumped, 0, 1) != 0) {
+      return;
+    }
+    _preimage_static_archive_recording_duration = Management::ticks_to_ms(os::elapsed_counter());
+  }
+
+
   if (CDSConfig::is_dumping_classic_static_archive()) {
     // We are running with -Xshare:dump
     preload_classes(CHECK);

--- a/src/hotspot/share/cds/metaspaceShared.hpp
+++ b/src/hotspot/share/cds/metaspaceShared.hpp
@@ -59,6 +59,8 @@ class MetaspaceShared : AllStatic {
   static char* _requested_base_address;
   static bool _use_optimized_module_handling;
   static Array<Method*>* _archived_method_handle_intrinsics;
+  static int volatile _preimage_static_archive_dumped;
+  static jlong _preimage_static_archive_recording_duration;
 
  public:
   enum {
@@ -109,6 +111,9 @@ public:
 
   static bool is_shared_dynamic(void* p) NOT_CDS_RETURN_(false);
   static bool is_shared_static(void* p) NOT_CDS_RETURN_(false);
+
+  static bool is_recording_preimage_static_archive() NOT_CDS_RETURN_(false);
+  static jlong get_preimage_static_archive_recording_duration() NOT_CDS_RETURN_(0);
 
   static void unrecoverable_loading_error(const char* message = "unrecoverable error");
   static void report_loading_error(const char* format, ...) ATTRIBUTE_PRINTF(1, 0);

--- a/src/hotspot/share/include/jvm.h
+++ b/src/hotspot/share/include/jvm.h
@@ -87,6 +87,21 @@ JVM_InternString(JNIEnv *env, jstring str);
 /*
  * java.lang.System
  */
+JNIEXPORT jboolean JNICALL
+JVM_AOTIsTraining(JNIEnv *env);
+
+JNIEXPORT jboolean JNICALL
+JVM_AOTEndTraining(JNIEnv *env);
+
+JNIEXPORT jstring JNICALL
+JVM_AOTGetMode(JNIEnv *env);
+
+JNIEXPORT jlong JNICALL
+JVM_AOTGetRecordingDuration(JNIEnv *env);
+
+/*
+ * java.lang.System
+ */
 JNIEXPORT jlong JNICALL
 JVM_CurrentTimeMillis(JNIEnv *env, jclass ignored);
 

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -229,6 +229,45 @@ extern void trace_class_resolution(Klass* to_class) {
 // java.lang.System //////////////////////////////////////////////////////////////////////
 
 
+JVM_LEAF(jboolean, JVM_AOTIsTraining(JNIEnv *env))
+#if INCLUDE_CDS
+  return MetaspaceShared::is_recording_preimage_static_archive();
+#else
+  return JNI_FALSE;
+#endif // INCLUDE_CDS
+JVM_END
+
+JVM_ENTRY(jboolean, JVM_AOTEndTraining(JNIEnv *env))
+#if INCLUDE_CDS
+  if (MetaspaceShared::is_recording_preimage_static_archive()) {
+    MetaspaceShared::preload_and_dump(THREAD);
+    return JNI_TRUE;
+  }
+  return JNI_FALSE;
+#else
+  return JNI_FALSE;
+#endif // INCLUDE_CDS
+JVM_END
+
+JVM_ENTRY(jstring, JVM_AOTGetMode(JNIEnv *env))
+  HandleMark hm(THREAD);
+#if INCLUDE_CDS
+  const char* mode = AOTMode == nullptr ? "auto" : AOTMode;
+  Handle h = java_lang_String::create_from_platform_dependent_str(mode, CHECK_NULL);
+  return (jstring) JNIHandles::make_local(THREAD, h());
+#else
+  return nullptr;
+#endif // INCLUDE_CDS
+JVM_END
+
+JVM_LEAF(jlong, JVM_AOTGetRecordingDuration(JNIEnv *env))
+#if INCLUDE_CDS
+  return MetaspaceShared::get_preimage_static_archive_recording_duration();
+#else
+  return 0;
+#endif // INCLUDE_CDS
+JVM_END
+
 JVM_LEAF(jlong, JVM_CurrentTimeMillis(JNIEnv *env, jclass ignored))
   return os::javaTimeMillis();
 JVM_END

--- a/src/hotspot/share/services/diagnosticCommand.cpp
+++ b/src/hotspot/share/services/diagnosticCommand.cpp
@@ -24,6 +24,7 @@
 
 #include "cds/cdsConfig.hpp"
 #include "cds/cds_globals.hpp"
+#include "cds/metaspaceShared.hpp"
 #include "classfile/classLoaderDataGraph.hpp"
 #include "classfile/classLoaderHierarchyDCmd.hpp"
 #include "classfile/classLoaderStats.hpp"
@@ -164,6 +165,10 @@ void DCmd::register_dcmds(){
 
 #if INCLUDE_CDS
   DCmdFactory::register_DCmdFactory(new DCmdFactoryImpl<DumpSharedArchiveDCmd>(full_export, true, false));
+#endif // INCLUDE_CDS
+
+#if INCLUDE_CDS
+  DCmdFactory::register_DCmdFactory(new DCmdFactoryImpl<AOTEndTrainingDCmd>(full_export, true, false));
 #endif // INCLUDE_CDS
 
   DCmdFactory::register_DCmdFactory(new DCmdFactoryImpl<NMTDCmd>(full_export, true, false));
@@ -984,6 +989,28 @@ void ClassesDCmd::execute(DCmdSource source, TRAPS) {
   VM_PrintClasses vmop(output(), _verbose.value());
   VMThread::execute(&vmop);
 }
+
+#if INCLUDE_CDS
+void AOTEndTrainingDCmd::execute(DCmdSource source, TRAPS) {
+  if (!CDSConfig::is_dumping_preimage_static_archive()) {
+    output()->print_cr("Error! Not a training run");
+    return;
+  }
+
+  if (!MetaspaceShared::is_recording_preimage_static_archive()) {
+    output()->print_cr("Error! Not recording");
+    return;
+  }
+
+  MetaspaceShared::preload_and_dump(THREAD);
+  if (!MetaspaceShared::is_recording_preimage_static_archive()) {
+    output()->print_cr("Training ended successfully");
+    return;
+  }
+
+  output()->print_cr("Error! Failed to end training");
+}
+#endif // INCLUDE_CDS
 
 #if INCLUDE_CDS
 #define DEFAULT_CDS_ARCHIVE_FILENAME "java_pid%p_<subcmd>.jsa"

--- a/src/hotspot/share/services/diagnosticCommand.hpp
+++ b/src/hotspot/share/services/diagnosticCommand.hpp
@@ -326,6 +326,21 @@ public:
 };
 
 #if INCLUDE_CDS
+class AOTEndTrainingDCmd : public DCmd {
+public:
+  AOTEndTrainingDCmd(outputStream* output, bool heap) : DCmd(output, heap) { }
+    static const char* name() { return "AOT.end_training"; }
+    static const char* description() {
+      return "End AOT training and create the cache.";
+    }
+    static const char* impact() {
+      return "Medium: Pause time depends on number of loaded classes";
+    }
+    virtual void execute(DCmdSource source, TRAPS);
+};
+#endif // INCLUDE_CDS
+
+#if INCLUDE_CDS
 class DumpSharedArchiveDCmd: public DCmdWithParser {
 protected:
   DCmdArgument<char*> _suboption;   // option of VM.cds

--- a/src/java.management/share/classes/sun/management/VMManagement.java
+++ b/src/java.management/share/classes/sun/management/VMManagement.java
@@ -48,6 +48,12 @@ public interface VMManagement {
     public boolean isGcNotificationSupported();
     public boolean isRemoteDiagnosticCommandsSupported();
 
+    // AOT Subsytem
+    public String  getAOTMode();
+    public boolean isAOTRecording();
+    public long    getAOTRecordingDuration();
+    public boolean endAOTRecording();
+
     // Class Loading Subsystem
     public long    getTotalClassCount();
     public int     getLoadedClassCount();

--- a/src/java.management/share/classes/sun/management/VMManagementImpl.java
+++ b/src/java.management/share/classes/sun/management/VMManagementImpl.java
@@ -117,6 +117,12 @@ class VMManagementImpl implements VMManagement {
     public native boolean isThreadCpuTimeEnabled();
     public native boolean isThreadAllocatedMemoryEnabled();
 
+    // AOT Subsystem
+    public native String  getAOTMode();
+    public native boolean isAOTRecording();
+    public native long    getAOTRecordingDuration();
+    public native boolean endAOTRecording();
+
     // Class Loading Subsystem
     public int    getLoadedClassCount() {
         long count = getTotalClassCount() - getUnloadedClassCount();

--- a/src/java.management/share/native/libmanagement/VMManagementImpl.c
+++ b/src/java.management/share/native/libmanagement/VMManagementImpl.c
@@ -101,6 +101,34 @@ Java_sun_management_VMManagementImpl_getVmArguments0
     return JVM_GetVmArguments(env);
 }
 
+JNIEXPORT jstring JNICALL
+Java_sun_management_VMManagementImpl_getAOTMode
+  (JNIEnv *env, jobject dummy)
+{
+    return JVM_AOTGetMode(env);
+}
+
+JNIEXPORT jboolean JNICALL
+Java_sun_management_VMManagementImpl_isAOTRecording
+  (JNIEnv *env, jobject dummy)
+{
+    return JVM_AOTIsTraining(env);
+}
+
+JNIEXPORT jlong JNICALL
+Java_sun_management_VMManagementImpl_getAOTRecordingDuration
+  (JNIEnv *env, jobject dummy)
+{
+    return JVM_AOTGetRecordingDuration(env);
+}
+
+JNIEXPORT jboolean JNICALL
+Java_sun_management_VMManagementImpl_endAOTRecording
+  (JNIEnv *env, jobject dummy)
+{
+    return JVM_AOTEndTraining(env);
+}
+
 JNIEXPORT jlong JNICALL
 Java_sun_management_VMManagementImpl_getTotalClassCount
   (JNIEnv *env, jobject dummy)

--- a/src/jdk.management/share/classes/com/sun/management/internal/AOTCacheImpl.java
+++ b/src/jdk.management/share/classes/com/sun/management/internal/AOTCacheImpl.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.sun.management.internal;
+
+import javax.management.ObjectName;
+import jdk.management.AOTCacheMXBean;
+import sun.management.Util;
+import sun.management.VMManagement;
+
+/**
+  * Implementation class for the AOT Cache subsystem.
+  *
+  * ManagementFactory.getRuntimeMXBean() returns an instance
+  * of this class.
+  */
+public class AOTCacheImpl implements AOTCacheMXBean {
+
+    private final VMManagement jvm;
+    /**
+      * Constructor of AOTCacheImpl class.
+      */
+      AOTCacheImpl(VMManagement vm) {
+         this.jvm = vm;
+     }
+
+     public String getMode() {
+         return jvm.getAOTMode();
+     }
+
+     public boolean isRecording() {
+         return jvm.isAOTRecording();
+     }
+
+     public long getRecordingDuration(){
+         return jvm.getAOTRecordingDuration();
+     }
+
+     public boolean endRecording(){
+         return jvm.endAOTRecording();
+     }
+
+     public ObjectName getObjectName() {
+         return Util.newObjectName("jdk.management:type=AOTCache");
+     }
+}
+

--- a/src/jdk.management/share/classes/com/sun/management/internal/PlatformMBeanProviderImpl.java
+++ b/src/jdk.management/share/classes/com/sun/management/internal/PlatformMBeanProviderImpl.java
@@ -39,6 +39,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.management.DynamicMBean;
+import jdk.management.AOTCacheMXBean;
 import jdk.management.VirtualThreadSchedulerMXBean;
 import sun.management.ManagementFactoryHelper;
 import sun.management.spi.PlatformMBeanProvider;
@@ -156,6 +157,41 @@ public final class PlatformMBeanProviderImpl extends PlatformMBeanProvider {
                 return Collections.singletonMap(
                         ManagementFactory.THREAD_MXBEAN_NAME,
                         threadMBean);
+            }
+        });
+
+        /**
+        * AOTCacheMXBean.
+        */
+        initMBeanList.add(new PlatformComponent<AOTCacheMXBean>() {
+            private final Set<Class<? extends AOTCacheMXBean>> mbeanInterfaces =
+                    Set.of(AOTCacheMXBean.class);
+            private final Set<String> mbeanInterfaceNames =
+                    Set.of(AOTCacheMXBean.class.getName());
+            private AOTCacheMXBean impl;
+
+            @Override
+            public Set<Class<? extends AOTCacheMXBean>> mbeanInterfaces() {
+                return mbeanInterfaces;
+            }
+
+            @Override
+            public Set<String> mbeanInterfaceNames() {
+                return mbeanInterfaceNames;
+            }
+
+            @Override
+            public String getObjectNamePattern() {
+                return "jdk.management:type=AOTCache";
+            }
+
+            @Override
+            public Map<String, AOTCacheMXBean> nameToMBeanMap() {
+                AOTCacheMXBean impl = this.impl;
+                if (impl == null) {
+                    this.impl = impl = new AOTCacheImpl(ManagementFactoryHelper.getVMManagement());
+                }
+                return Map.of("jdk.management:type=AOTCache", impl);
             }
         });
 

--- a/src/jdk.management/share/classes/jdk/management/AOTCacheMXBean.java
+++ b/src/jdk.management/share/classes/jdk/management/AOTCacheMXBean.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jdk.management;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.PlatformManagedObject;
+import java.util.concurrent.ForkJoinPool;
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+
+/**
+ * Management interface for the JDK's AOT system.
+ *
+ * <p> {@code AOTCacheMXBean} supports inspection of the current AOT mode, as well as monitoring
+ * the current recording length. It also supports dynamically ending the current recording.
+ *
+ * <p> The management interface is registered with the platform {@link MBeanServer
+ * MBeanServer}. The {@link ObjectName ObjectName} that uniquely identifies the management
+ * interface within the {@code MBeanServer} is: "jdk.management:type=AOTCache".
+ *
+ * <p> Direct access to the MXBean interface can be obtained with
+ * {@link ManagementFactory#getPlatformMXBean(Class)}.
+ *
+ * @since 25
+ */
+public interface AOTCacheMXBean extends PlatformManagedObject {
+     /**
+      * Returns the string representing the current AOT mode of
+      * operation.
+      *
+      * @return the string representing the current AOT mode.
+      */
+      public String getMode();
+
+      /**
+       * Tests if a recording is in progress.
+       *
+       * @return {@code true} if a recording is in progress; {@code false} otherwise.
+       */
+      public boolean isRecording();
+
+      /**
+       * If a recording is in progress or has been completed, then returns the duration in milliseconds
+       *
+       * @return duration of the recording in milliseconds.
+       */
+      public long getRecordingDuration();
+
+      /**
+       * If a recording is in progress, then ends the recording.
+       *
+       * @return {@code true} if a recording was stopped; {@code false} otherwise.
+       */
+      public boolean endRecording();
+}

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotCache/AOTCacheMXBeanTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotCache/AOTCacheMXBeanTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, Microsoft, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -79,11 +79,7 @@ public class AOTCacheMXBeanTest {
             if (runMode.isApplicationExecuted()) {
                 out.shouldContain("Hello Leyden " + name);
                 if(runMode == RunMode.TRAINING) {
-                    if (false) {
-                        out.shouldContain("AOTMode = auto");
-                    } else {
-                        out.shouldContain("AOTMode = record");
-                    }
+                    out.shouldContain("AOTMode = record");
                     out.shouldContain("Confirmed is recording");
                     out.shouldContain("Confirmed recording duration > 0");
                     out.shouldContain("Stopped recording successfully after an additional 10ms");
@@ -93,11 +89,7 @@ public class AOTCacheMXBeanTest {
                 } else if (runMode == RunMode.ASSEMBLY) {
                     out.shouldNotContain("Hello Leyden ");
                 } else if (runMode == RunMode.PRODUCTION) {
-                    if (false) {
-                        out.shouldContain("AOTMode = auto");
-                    } else {
-                        out.shouldContain("AOTMode = on");
-                    }
+                    out.shouldContain("AOTMode = on");
                     out.shouldContain("Confirmed is not recording");
                     out.shouldContain("Confirmed recording duration == 0");
                 }

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotCache/AOTCacheMXBeanTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotCache/AOTCacheMXBeanTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+
+/*
+ * @test
+ * @summary Sanity test for AOTCache MXBean
+ * @requires vm.cds.write.archived.java.heap
+ * @library /test/jdk/lib/testlibrary /test/lib
+ *          /test/hotspot/jtreg/runtime/cds/appcds/aotCache/test-classes
+ * @build AOTCacheMXBeanTest
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar app.jar AOTCacheMXBeanApp
+ * @run driver AOTCacheMXBeanTest
+ */
+
+import jdk.test.lib.cds.CDSAppTester;
+import jdk.test.lib.helpers.ClassFileInstaller;
+import jdk.test.lib.process.OutputAnalyzer;
+import java.lang.management.ManagementFactory;
+import jdk.management.AOTCacheMXBean;
+
+public class AOTCacheMXBeanTest {
+    static final String appJar = ClassFileInstaller.getJarPath("app.jar");
+    static final String mainClass = "AOTCacheMXBeanApp";
+    public static void main(String[] args) throws Exception {
+        Tester tester = new Tester();
+        tester.runAOTWorkflow();
+    }
+
+    static class Tester extends CDSAppTester {
+        public Tester() {
+            super(mainClass);
+        }
+
+        @Override
+        public String classpath(RunMode runMode) {
+            return appJar;
+        }
+
+        @Override
+        public String[] vmArgs(RunMode runMode) {
+            return new String[] {
+               "-Xlog:cds+class=trace",
+                "--add-modules=jdk.management"
+            };
+        }
+
+        @Override
+        public String[] appCommandLine(RunMode runMode) {
+            return new String[] {
+                mainClass, runMode.name()
+            };
+        }
+
+        @Override
+        public void checkExecution(OutputAnalyzer out, RunMode runMode) {
+            var name = runMode.name();
+            if (runMode.isApplicationExecuted()) {
+                out.shouldContain("Hello Leyden " + name);
+                if(runMode == RunMode.TRAINING) {
+                    if (false) {
+                        out.shouldContain("AOTMode = auto");
+                    } else {
+                        out.shouldContain("AOTMode = record");
+                    }
+                    out.shouldContain("Confirmed is recording");
+                    out.shouldContain("Confirmed recording duration > 0");
+                    out.shouldContain("Stopped recording successfully after an additional 10ms");
+                    out.shouldContain("Last recording duration > than previous duration");
+                    out.shouldContain("Confirmed recording stopped");
+                    out.shouldContain("Confirmed recording duration has not changed after 10ms");
+                } else if (runMode == RunMode.ASSEMBLY) {
+                    out.shouldNotContain("Hello Leyden ");
+                } else if (runMode == RunMode.PRODUCTION) {
+                    if (false) {
+                        out.shouldContain("AOTMode = auto");
+                    } else {
+                        out.shouldContain("AOTMode = on");
+                    }
+                    out.shouldContain("Confirmed is not recording");
+                    out.shouldContain("Confirmed recording duration == 0");
+                }
+                out.shouldNotContain("Thread interrupted");
+                out.shouldNotContain("Failed to stop recording");
+            }
+        }
+    }
+}
+
+class AOTCacheMXBeanApp {
+    public static void main(String[] args) {
+        System.out.println("Hello Leyden " + args[0]);
+        var aotBean = ManagementFactory.getPlatformMXBean(AOTCacheMXBean.class);
+        if (aotBean == null) {
+            System.out.println("AOTCacheMXBean is not available");
+            return;
+        }
+        System.out.println("AOTMode = " + aotBean.getMode());
+        if (aotBean.isRecording()) {
+            try {
+                System.out.println("Confirmed is recording");
+                var initialDuration = aotBean.getRecordingDuration();
+                System.out.println("Confirmed recording duration > 0");
+                Thread.sleep(10);
+                if (aotBean.endRecording()) {
+                    System.out.println("Stopped recording successfully after an additional 10ms");
+                    if (!aotBean.isRecording()) {
+                        System.out.println("Confirmed recording stopped");
+                    }
+                    var recordingDuration = aotBean.getRecordingDuration();
+                    if (recordingDuration > initialDuration) {
+                        System.out.println("Last recording duration > than previous duration");
+                    }
+                    Thread.sleep(10);
+                    var lastDuration = aotBean.getRecordingDuration();
+                    if (lastDuration == recordingDuration) {
+                        System.out.println("Confirmed recording duration has not changed after 10ms");
+                    }
+                } else {
+                    System.out.println("Failed to stop recording");
+                }
+            } catch (InterruptedException e) {
+                System.out.println("Thread interrupted");
+            }
+        } else {
+            System.out.println("Confirmed is not recording");
+            var recordingDuration = aotBean.getRecordingDuration();
+            if (recordingDuration == 0) {
+                System.out.println("Confirmed recording duration == 0");
+            }
+        }
+    }
+}

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotCache/JcmdAOTEndTrainingTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotCache/JcmdAOTEndTrainingTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @requires vm.cds.supports.aot.class.linking
+ * @requires vm.cds.write.archived.java.heap
+ * @summary Sanity test for Jcmd AOT.end_training command
+ * @library /test/lib
+ * @build JcmdAOTEndTrainingTest
+ * @run driver JcmdAOTEndTrainingTest
+ */
+
+import jdk.test.lib.JDKToolLauncher;
+import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.apps.LingeredApp;
+import jdk.test.lib.dcmd.PidJcmdExecutor;
+import jdk.test.lib.process.OutputAnalyzer;
+import java.io.IOException;
+
+public class JcmdAOTEndTrainingTest {
+    public static void main(String[] args)  throws Exception {
+        LingeredApp theApp = null;
+        try {
+            theApp = new LingeredApp();
+            theApp.setUseDefaultClasspath(false);
+            LingeredApp.startApp(theApp);
+            long pid = theApp.getPid();
+
+            JDKToolLauncher jcmd = JDKToolLauncher.createUsingTestJDK("jcmd");
+            jcmd.addToolArg(String.valueOf(pid));
+            jcmd.addToolArg("AOT.end_training");
+
+            try {
+                OutputAnalyzer output = ProcessTools.executeProcess(jcmd.getCommand());
+                output.shouldContain("Error! Not a training run");
+            } catch (Exception e) {
+                throw new RuntimeException("Test failed: " + e);
+            }
+        }
+        catch (IOException e) {
+            throw new RuntimeException("Test failed: " + e);
+        }
+        finally {
+            LingeredApp.stopApp(theApp);
+        }
+    }
+}

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotCache/JcmdAOTEndTrainingTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotCache/JcmdAOTEndTrainingTest.java
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
- * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * Copyright (c) 2025, Microsoft, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Draft while I add tests

This PR pulls in two changes from github.com/openjdk/leyden premain branch

1) AOTCache MX Bean
2) JCmd AOT.end_training

The JCmd implementation had to change slightly as it originally called the metaspace code indirectly through CDSUpCalls; however that system is not pulled across