### PR TITLE
ml64 should not be the assembler on Windows aarch64

### DIFF
--- a/make/autoconf/flags-other.m4
+++ b/make/autoconf/flags-other.m4
@@ -115,7 +115,11 @@ AC_DEFUN([FLAGS_SETUP_ASFLAGS],
     # Force preprocessor to run, just to make sure
     BASIC_ASFLAGS="-x assembler-with-cpp"
   elif test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
-    BASIC_ASFLAGS="-nologo -c"
+    if test "x$OPENJDK_TARGET_CPU" = xaarch64; then
+      BASIC_ASFLAGS="-nologo"
+    else
+      BASIC_ASFLAGS="-nologo -c -Ta"
+    fi
   fi
   AC_SUBST(BASIC_ASFLAGS)
 

--- a/make/autoconf/toolchain.m4
+++ b/make/autoconf/toolchain.m4
@@ -655,12 +655,17 @@ AC_DEFUN_ONCE([TOOLCHAIN_DETECT_TOOLCHAIN_CORE],
   if test "x$TOOLCHAIN_TYPE" != xmicrosoft; then
     AS="$CC -c"
   else
-    if test "x$OPENJDK_TARGET_CPU_BITS" = "x64"; then
-      # On 64 bit windows, the assembler is "ml64.exe"
-      UTIL_LOOKUP_TOOLCHAIN_PROGS(AS, ml64)
+    if test "x$OPENJDK_TARGET_CPU" = "xaarch64"; then
+      # On Windows aarch64, the assembler is "armasm64.exe"
+      UTIL_LOOKUP_TOOLCHAIN_PROGS(AS, armasm64)
     else
-      # otherwise, the assembler is "ml.exe"
-      UTIL_LOOKUP_TOOLCHAIN_PROGS(AS, ml)
+      if test "x$OPENJDK_TARGET_CPU_BITS" = "x64"; then
+        # On Windows x64, the assembler is "ml64.exe"
+        UTIL_LOOKUP_TOOLCHAIN_PROGS(AS, ml64)
+      else
+        # otherwise, the assembler is "ml.exe"
+        UTIL_LOOKUP_TOOLCHAIN_PROGS(AS, ml)
+      fi
     fi
   fi
   AC_SUBST(AS)

--- a/make/common/native/CompileFile.gmk
+++ b/make/common/native/CompileFile.gmk
@@ -236,7 +236,7 @@ define CreateCompiledNativeFileBody
             # For assembler calls just create empty dependency lists
 	    $$(call ExecuteWithLog, $$@, $$(call MakeCommandRelative, \
 	        $$($1_COMPILER) $$($1_FLAGS) \
-	        $(CC_OUT_OPTION)$$($1_OBJ) -Ta $$($1_SRC_FILE))) \
+	        $(CC_OUT_OPTION)$$($1_OBJ) $$($1_SRC_FILE))) \
 	        | $(TR) -d '\r' | $(GREP) -v -e "Assembling:" || test "$$$$?" = "1" ; \
 	    $(ECHO) > $$($1_DEPS_FILE) ; \
 	    $(ECHO) > $$($1_DEPS_TARGETS_FILE)


### PR DESCRIPTION
[ml64](https://learn.microsoft.com/en-us/cpp/assembler/masm/ml-and-ml64-command-line-reference?view=msvc-170) is set as the assembler for the Windows platform but is specific to the x64 platform. The [armasm64](https://learn.microsoft.com/en-us/cpp/assembler/arm/arm-assembler-command-line-reference?view=msvc-170) assembler should be used for Windows AArch64.

The -Ta option is only valid for ml64 and should be removed from CompileFile.gmk.