### PR TITLE
Detect CPU support for PMULL, LSE, SHA3, and SHA512 on Windows/AArch64

### DIFF
--- a/src/hotspot/os_cpu/windows_aarch64/vm_version_windows_aarch64.cpp
+++ b/src/hotspot/os_cpu/windows_aarch64/vm_version_windows_aarch64.cpp
@@ -43,15 +43,31 @@ void VM_Version::get_os_cpu_info() {
   if (IsProcessorFeaturePresent(PF_ARM_V8_CRC32_INSTRUCTIONS_AVAILABLE)) {
     set_feature(CPU_CRC32);
   }
+
   if (IsProcessorFeaturePresent(PF_ARM_V8_CRYPTO_INSTRUCTIONS_AVAILABLE)) {
     set_feature(CPU_AES);
     set_feature(CPU_SHA1);
     set_feature(CPU_SHA2);
+    set_feature(CPU_PMULL);
   }
+
   if (IsProcessorFeaturePresent(PF_ARM_VFP_32_REGISTERS_AVAILABLE)) {
     set_feature(CPU_ASIMD);
   }
-  // No check for CPU_PMULL, CPU_SVE, CPU_SVE2
+
+  if (IsProcessorFeaturePresent(PF_ARM_V81_ATOMIC_INSTRUCTIONS_AVAILABLE)) {
+    set_feature(CPU_LSE);
+  }
+
+  if (IsProcessorFeaturePresent(PF_ARM_SHA3_INSTRUCTIONS_AVAILABLE)) {
+    set_feature(CPU_SHA3);
+  }
+
+  if (IsProcessorFeaturePresent(PF_ARM_SHA512_INSTRUCTIONS_AVAILABLE)) {
+    set_feature(CPU_SHA512);
+  }
+
+  // No check for DCPOP, SB, PACA, A53MAC
 
   __int64 dczid_el0 = _ReadStatusReg(0x5807 /* ARM64_DCZID_EL0 */);
 

--- a/test/hotspot/jtreg/compiler/arguments/TestUseGHASHIntrinsicsOnAArch64.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestUseGHASHIntrinsicsOnAArch64.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Verify UseGHASHIntrinsics option processing on AArch64.
+ * @library /test/lib /
+ * @requires os.arch == "aarch64"
+ * @requires vm.flagless
+ *
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+WhiteBoxAPI
+ *                   compiler.arguments.TestUseGHASHIntrinsicsOnAArch64
+ */
+
+package compiler.arguments;
+
+import jdk.test.lib.Asserts;
+import jdk.test.lib.cli.CommandLineOptionTest;
+import jdk.test.whitebox.WhiteBox;
+import jdk.test.whitebox.cpuinfo.CPUInfo;
+
+public class TestUseGHASHIntrinsicsOnAArch64 {
+
+    private static final WhiteBox WB = WhiteBox.getWhiteBox();
+    private static final String OPTION_NAME = "UseGHASHIntrinsics";
+    private static final String WARNING_MESSAGE =
+        "GHASH intrinsics are not available on this CPU";
+
+    public static void main(String[] args) throws Throwable {
+        boolean hasPmull = CPUInfo.hasFeature("pmull");
+        Boolean useGHASH = WB.getBooleanVMFlag(OPTION_NAME);
+
+        System.out.println("CPU has PMULL: " + hasPmull);
+        System.out.println("UseGHASHIntrinsics flag: " + useGHASH);
+
+        if (hasPmull) {
+            Asserts.assertTrue(useGHASH != null && useGHASH,
+                "UseGHASHIntrinsics should be auto-enabled when CPU supports PMULL");
+            return;
+        }
+
+        Asserts.assertTrue(useGHASH == null || !useGHASH,
+            "UseGHASHIntrinsics should be false when CPU does not support PMULL");
+
+        CommandLineOptionTest.verifyOptionValueForSameVM(
+            OPTION_NAME, "false",
+            "UseGHASHIntrinsics should be false on unsupported CPU even if enabled",
+            CommandLineOptionTest.prepareBooleanFlag(OPTION_NAME, true));
+    }
+}

--- a/test/hotspot/jtreg/compiler/arguments/TestUseLSEOnAArch64.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestUseLSEOnAArch64.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Verify UseLSE option processing on AArch64.
+ * @library /test/lib /
+ * @requires os.arch == "aarch64"
+ * @requires vm.flagless
+ *
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+WhiteBoxAPI
+ *                   compiler.arguments.TestUseLSEOnAArch64
+ */
+
+package compiler.arguments;
+
+import jdk.test.lib.Asserts;
+import jdk.test.lib.cli.CommandLineOptionTest;
+import jdk.test.whitebox.WhiteBox;
+import jdk.test.whitebox.cpuinfo.CPUInfo;
+
+public class TestUseLSEOnAArch64 {
+
+    private static final WhiteBox WB = WhiteBox.getWhiteBox();
+    private static final String OPTION_NAME = "UseLSE";
+    private static final String WARNING_MESSAGE =
+        "UseLSE specified, but not supported on this CPU";
+
+    public static void main(String[] args) throws Throwable {
+        boolean hasLSE = CPUInfo.hasFeature("lse");
+        Boolean useLSE = WB.getBooleanVMFlag(OPTION_NAME);
+
+        System.out.println("CPU has LSE: " + hasLSE);
+        System.out.println("UseLSE flag: " + useLSE);
+
+        if (hasLSE) {
+            Asserts.assertTrue(useLSE != null && useLSE,
+                "UseLSE should be auto-enabled when CPU supports LSE atomics");
+            return;
+        }
+
+        Asserts.assertTrue(useLSE == null || !useLSE,
+            "UseLSE should be false when CPU does not support LSE atomics");
+
+        CommandLineOptionTest.verifyOptionValueForSameVM(
+            OPTION_NAME, "false",
+            "UseLSE should be false on unsupported CPU even if enabled",
+            CommandLineOptionTest.prepareBooleanFlag(OPTION_NAME, true));
+    }
+}

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/test/ApplicableIRRulesPrinter.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/test/ApplicableIRRulesPrinter.java
@@ -114,6 +114,9 @@ public class ApplicableIRRulesPrinter {
         "apx_f",
         // AArch64
         "sha3",
+        "sha512",
+        "pmull",
+        "lse",
         "asimd",
         "sve",
         "sve2",


### PR DESCRIPTION
This patch augments vm_version_windows_aarch64.cpp to detect hardware
support for PMULL (for polynomial multiplication on long types), LSE
(for atomic instructions), and SHA3 and SHA512 (for cryptographic
instructions).  This patch also introduces two new tests that check the
impact of enabling or disabling these CPU features using command line
flags in the presence or absence of these CPU features.