### PR TITLE
Only create exception objects if we're going to `throw` them

### DIFF
--- a/src/java.base/share/classes/sun/security/tools/keytool/Main.java
+++ b/src/java.base/share/classes/sun/security/tools/keytool/Main.java
@@ -4305,11 +4305,9 @@ public final class Main {
     private static Date getStartDate(String s) throws IOException {
         Calendar c = new GregorianCalendar();
         if (s != null) {
-            IOException ioe = new IOException(
-                    rb.getString("Illegal.startdate.value"));
             int len = s.length();
             if (len == 0) {
-                throw ioe;
+                throw new IOException(rb.getString("Illegal.startdate.value"));
             }
             if (s.charAt(0) == '-' || s.charAt(0) == '+') {
                 // Form 1: ([+-]nnn[ymdHMS])+
@@ -4319,16 +4317,16 @@ public final class Main {
                     switch (s.charAt(start)) {
                         case '+': sign = 1; break;
                         case '-': sign = -1; break;
-                        default: throw ioe;
+                        default: throw new IOException(rb.getString("Illegal.startdate.value"));
                     }
                     int i = start+1;
                     for (; i<len; i++) {
                         char ch = s.charAt(i);
                         if (ch < '0' || ch > '9') break;
                     }
-                    if (i == start+1) throw ioe;
+                    if (i == start+1) throw new IOException(rb.getString("Illegal.startdate.value"));
                     int number = Integer.parseInt(s.substring(start+1, i));
-                    if (i >= len) throw ioe;
+                    if (i >= len) throw new IOException(rb.getString("Illegal.startdate.value"));
                     int unit;
                     switch (s.charAt(i)) {
                         case 'y': unit = Calendar.YEAR; break;
@@ -4337,7 +4335,7 @@ public final class Main {
                         case 'H': unit = Calendar.HOUR; break;
                         case 'M': unit = Calendar.MINUTE; break;
                         case 'S': unit = Calendar.SECOND; break;
-                        default: throw ioe;
+                        default: throw new IOException(rb.getString("Illegal.startdate.value"));
                     }
                     c.add(unit, sign * number);
                     start = i + 1;
@@ -4349,13 +4347,13 @@ public final class Main {
                     date = s.substring(0, 10);
                     time = s.substring(11);
                     if (s.charAt(10) != ' ')
-                        throw ioe;
+                        throw new IOException(rb.getString("Illegal.startdate.value"));
                 } else if (len == 10) {
                     date = s;
                 } else if (len == 8) {
                     time = s;
                 } else {
-                    throw ioe;
+                    throw new IOException(rb.getString("Illegal.startdate.value"));
                 }
                 if (date != null) {
                     if (date.matches("\\d\\d\\d\\d/\\d\\d/\\d\\d")) {
@@ -4363,7 +4361,7 @@ public final class Main {
                                 Integer.parseInt(date.substring(5, 7))-1,
                                 Integer.parseInt(date.substring(8, 10)));
                     } else {
-                        throw ioe;
+                        throw new IOException(rb.getString("Illegal.startdate.value"));
                     }
                 }
                 if (time != null) {
@@ -4373,7 +4371,7 @@ public final class Main {
                         c.set(Calendar.SECOND, Integer.parseInt(time.substring(6, 8)));
                         c.set(Calendar.MILLISECOND, 0);
                     } else {
-                        throw ioe;
+                        throw new IOException(rb.getString("Illegal.startdate.value"));
                     }
                 }
             }

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/Connection.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/Connection.java
@@ -1175,7 +1175,7 @@ public final class Connection implements Runnable {
             } catch (SSLPeerUnverifiedException ex) {
                 CommunicationException ce = new CommunicationException();
                 ce.setRootCause(closureReason);
-                tlsHandshakeCompleted.completeExceptionally(ex);
+                tlsHandshakeCompleted.completeExceptionally(ce);
             }
         }
     }

--- a/src/jdk.internal.le/share/classes/jdk/internal/org/jline/terminal/impl/AbstractPty.java
+++ b/src/jdk.internal.le/share/classes/jdk/internal/org/jline/terminal/impl/AbstractPty.java
@@ -160,7 +160,7 @@ public abstract class AbstractPty implements Pty {
             String str =
                     System.getProperty(PROP_FILE_DESCRIPTOR_CREATION_MODE, PROP_FILE_DESCRIPTOR_CREATION_MODE_DEFAULT);
             String[] modes = str.split(",");
-            IllegalStateException ise = new IllegalStateException("Unable to create FileDescriptor");
+            IllegalStateException ise = null;
             for (String mode : modes) {
                 try {
                     switch (mode) {
@@ -173,6 +173,9 @@ public abstract class AbstractPty implements Pty {
                     }
                 } catch (Throwable t) {
                     // ignore
+                    if (ise == null) {
+                        ise = new IllegalStateException("Unable to create FileDescriptor");
+                    }
                     ise.addSuppressed(t);
                 }
                 if (fileDescriptorCreator != null) {
@@ -180,7 +183,7 @@ public abstract class AbstractPty implements Pty {
                 }
             }
             if (fileDescriptorCreator == null) {
-                throw ise;
+                throw ise != null ? ise : new IllegalStateException("Unable to create FileDescriptor");
             }
         }
         return fileDescriptorCreator.newDescriptor(fd);

--- a/src/jdk.internal.le/share/classes/jdk/internal/org/jline/terminal/impl/exec/ExecTerminalProvider.java
+++ b/src/jdk.internal.le/share/classes/jdk/internal/org/jline/terminal/impl/exec/ExecTerminalProvider.java
@@ -188,7 +188,7 @@ public class ExecTerminalProvider implements TerminalProvider {
         if (redirectPipeCreator == null) {
             String str = System.getProperty(PROP_REDIRECT_PIPE_CREATION_MODE, PROP_REDIRECT_PIPE_CREATION_MODE_DEFAULT);
             String[] modes = str.split(",");
-            IllegalStateException ise = new IllegalStateException("Unable to create RedirectPipe");
+            IllegalStateException ise = null;
             for (String mode : modes) {
                 try {
                     switch (mode) {
@@ -201,6 +201,9 @@ public class ExecTerminalProvider implements TerminalProvider {
                     }
                 } catch (Throwable t) {
                     // ignore
+                    if (ise == null) {
+                        ise = new IllegalStateException("Unable to create RedirectPipe");
+                    }
                     ise.addSuppressed(t);
                 }
                 if (redirectPipeCreator != null) {
@@ -208,7 +211,7 @@ public class ExecTerminalProvider implements TerminalProvider {
                 }
             }
             if (redirectPipeCreator == null) {
-                throw ise;
+                throw ise != null ? ise : new IllegalStateException("Unable to create RedirectPipe");
             }
         }
         return redirectPipeCreator.newRedirectPipe(fd);

--- a/test/jdk/javax/net/ssl/TLSCommon/RehandshakeWithDataExTest.java
+++ b/test/jdk/javax/net/ssl/TLSCommon/RehandshakeWithDataExTest.java
@@ -64,13 +64,12 @@ public class RehandshakeWithDataExTest extends SSLEngineTestCase {
                 HandshakeMode.REHANDSHAKE_BEGIN_CLIENT);
         sendApplicationData(clientEngine, serverEngine);
         r = sendApplicationData(serverEngine, clientEngine);
-        AssertionError epochError = new AssertionError("Epoch number"
-                + " did not grow after re-handshake! "
-                + " Was " + initialEpoch + ", now " + secondEpoch + ".");
         if (TESTED_SECURITY_PROTOCOL.contains("DTLS")) {
             secondEpoch = r.sequenceNumber() >> 48;
             if (Long.compareUnsigned(secondEpoch, initialEpoch) <= 0) {
-                throw epochError;
+                throw new AssertionError("Epoch number"
+                        + " did not grow after re-handshake! "
+                        + " Was " + initialEpoch + ", now " + secondEpoch + ".");
             }
         }
         doHandshake(clientEngine, serverEngine, maxPacketSize,
@@ -78,9 +77,11 @@ public class RehandshakeWithDataExTest extends SSLEngineTestCase {
         sendApplicationData(clientEngine, serverEngine);
         r = sendApplicationData(serverEngine, clientEngine);
         if (TESTED_SECURITY_PROTOCOL.contains("DTLS")) {
-        thirdEpoch = r.sequenceNumber() >> 48;
+            thirdEpoch = r.sequenceNumber() >> 48;
             if (Long.compareUnsigned(thirdEpoch, secondEpoch) <= 0) {
-                throw epochError;
+                throw new AssertionError("Epoch number"
+                        + " did not grow after re-handshake! "
+                        + " Was " + secondEpoch + ", now " + thirdEpoch + ".");
             }
         }
         closeEngines(clientEngine, serverEngine);


### PR DESCRIPTION
As I understand, every time an exception object is created, the
constructor calls `fillInStackTrace()`, which has to walk the call stack
to record every frame.  This is expensive, but it's also unnecessary if
the exception is never thrown.  There are a few instances in various
parts of the JDK libraries where we create an exception in the dominator
block but don't always throw it.  This patch fixes those cases so that
if the exception is not going to be thrown, it is never created in the
first place.