### PR TITLE
Replace `GetFileInformationByHandle()` with `GetFileInformationByName()`

### DIFF
--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -40,6 +40,7 @@
 #include "nmt/memTracker.hpp"
 #include "oops/oop.inline.hpp"
 #include "os_windows.inline.hpp"
+#include "os_windows_fileinfo.hpp"
 #include "prims/jniFastGetField.hpp"
 #include "prims/jvm_misc.hpp"
 #include "runtime/arguments.hpp"
@@ -4490,6 +4491,10 @@ size_t os::_vm_internal_thread_min_stack_allowed = 64 * K;
 // If -Xss is given to the launcher, it will pick 64K as default stack size and pass that.
 size_t os::_os_min_stack_allowed = 64 * K;
 
+// For dynamic lookup of GetFileInformationByName API, since it is not available
+// on older versions of the Windows SDK.
+static PGetFileInformationByName _GetFileInformationByName = nullptr;
+
 // this is called _after_ the global arguments have been parsed
 jint os::init_2(void) {
   const char* auto_schedules_message = "Host Windows OS automatically schedules threads across all processor groups.";
@@ -4576,6 +4581,18 @@ jint os::init_2(void) {
   }
   log_info(os, thread)("The SetThreadDescription API is%s available.", _SetThreadDescription == nullptr ? " not" : "");
 
+  // Resolve GetFileInformationByName if available.  API preset mentioned here:
+  // https://github.com/MicrosoftDocs/sdk-api/blob/docs/sdk-api-src/content/winbase/nf-winbase-getfileinformationbyname.md
+  HMODULE hFileInfoMod = ::LoadLibrary(TEXT("api-ms-win-core-file-l2-1-4"));
+
+  if (hFileInfoMod != nullptr) {
+    _GetFileInformationByName =
+        reinterpret_cast<PGetFileInformationByName>(
+            ::GetProcAddress(hFileInfoMod, "GetFileInformationByName"));
+  }
+
+  log_info(os)("The GetFileInformationByName API is%s available.",
+               _GetFileInformationByName == nullptr ? " not" : "");
 
   return JNI_OK;
 }
@@ -4865,6 +4882,42 @@ bool os::same_files(const char* file1, const char* file2) {
     return true;
   }
 
+  if (_GetFileInformationByName != nullptr) {
+    // Fast path: use `GetFileInformationByName()` to avoid opening file handles
+    errno_t err1;
+    errno_t err2;
+    wchar_t* wide1 = wide_abs_unc_path(native_file1, err1);
+    wchar_t* wide2 = wide_abs_unc_path(native_file2, err2);
+
+    if (wide1 != nullptr && wide2 != nullptr && err1 == 0 && err2 == 0) {
+      FILE_STAT_BASIC_INFORMATION info1, info2;
+      if (_GetFileInformationByName(wide1, FileStatBasicByNameInfo,
+                                    &info1, sizeof(info1)) &&
+          _GetFileInformationByName(wide2, FileStatBasicByNameInfo,
+                                    &info2, sizeof(info2))) {
+        // Only use the fast path result when neither path is a reparse point
+        // (filesystem entries that contain special data blocks for symbolic
+        // links, etc.).
+        if (!(info1.FileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) &&
+            !(info2.FileAttributes & FILE_ATTRIBUTE_REPARSE_POINT)) {
+          bool same = (info1.VolumeSerialNumber.QuadPart ==
+                         info2.VolumeSerialNumber.QuadPart) &&
+                      (memcmp(&info1.FileId128, &info2.FileId128,
+                              sizeof(FILE_ID_128)) == 0);
+          os::free(wide1);
+          os::free(wide2);
+          os::free(native_file1);
+          os::free(native_file2);
+          return same;
+        }
+      }
+    }
+
+    os::free(wide1);
+    os::free(wide2);
+  }
+
+  // Slow path: open handles and check using `GetFileInformationByHandle()`.
   HANDLE handle1 = create_read_only_file_handle(native_file1);
   HANDLE handle2 = create_read_only_file_handle(native_file2);
   bool result = false;

--- a/src/hotspot/os/windows/os_windows_fileinfo.hpp
+++ b/src/hotspot/os/windows/os_windows_fileinfo.hpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef OS_WINDOWS_OS_WINDOWS_FILEINFO_HPP
+#define OS_WINDOWS_OS_WINDOWS_FILEINFO_HPP
+
+#include <windows.h>
+
+// SDK-guarded definitions for GetFileInformationByName and related types.
+// These are provided so that OpenJDK can be built with older Windows SDKs
+// that do not include these declarations.
+//
+// Keep FILE_STAT_BASIC_INFORMATION and FILE_INFO_BY_NAME_CLASS in sync with
+// WindowsNativeDispatcher.c.
+
+#if !defined(NTDDI_WIN10_NI) || !(NTDDI_VERSION >= NTDDI_WIN10_NI)
+
+typedef struct _FILE_STAT_BASIC_INFORMATION {
+    LARGE_INTEGER FileId;
+    LARGE_INTEGER CreationTime;
+    LARGE_INTEGER LastAccessTime;
+    LARGE_INTEGER LastWriteTime;
+    LARGE_INTEGER ChangeTime;
+    LARGE_INTEGER AllocationSize;
+    LARGE_INTEGER EndOfFile;
+    ULONG         FileAttributes;
+    ULONG         ReparseTag;
+    ULONG         NumberOfLinks;
+    ULONG         DeviceType;
+    ULONG         DeviceCharacteristics;
+    ULONG         Reserved;
+    LARGE_INTEGER VolumeSerialNumber;
+    FILE_ID_128   FileId128;
+} FILE_STAT_BASIC_INFORMATION;
+
+typedef enum _FILE_INFO_BY_NAME_CLASS {
+    FileStatByNameInfo,
+    FileStatLxByNameInfo,
+    FileCaseSensitiveByNameInfo,
+    FileStatBasicByNameInfo,
+    MaximumFileInfoByNameClass
+} FILE_INFO_BY_NAME_CLASS;
+
+#endif // !defined(NTDDI_WIN10_NI) || !(NTDDI_VERSION >= NTDDI_WIN10_NI)
+
+typedef BOOL (WINAPI *PGetFileInformationByName)(
+    PCWSTR                  FileName,
+    FILE_INFO_BY_NAME_CLASS FileInformationClass,
+    PVOID                   FileInfoBuffer,
+    ULONG                   FileInfoBufferSize
+);
+
+#endif // OS_WINDOWS_OS_WINDOWS_FILEINFO_HPP

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsConstants.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsConstants.java
@@ -96,6 +96,7 @@ class WindowsConstants {
     public static final int ERROR_NOT_SAME_DEVICE       = 17;
     public static final int ERROR_NOT_READY             = 21;
     public static final int ERROR_SHARING_VIOLATION     = 32;
+    public static final int ERROR_NOT_SUPPORTED         = 50;
     public static final int ERROR_NETWORK_ACCESS_DENIED = 65;
     public static final int ERROR_FILE_EXISTS           = 80;
     public static final int ERROR_INVALID_PARAMETER     = 87;
@@ -114,6 +115,12 @@ class WindowsConstants {
     public static final int ERROR_CANT_RESOLVE_FILENAME = 1921;
     public static final int ERROR_NOT_A_REPARSE_POINT   = 4390;
     public static final int ERROR_INVALID_REPARSE_DATA  = 4392;
+
+    // FILE_INFO_BY_NAME_CLASS enum values for `GetFileInformationByName()`
+    public static final int FileStatByNameInfo          = 0;
+    public static final int FileStatLxByNameInfo        = 1;
+    public static final int FileCaseSensitiveByNameInfo = 2;
+    public static final int FileStatBasicByNameInfo     = 3;
 
     // notify filters
     public static final int FILE_NOTIFY_CHANGE_FILE_NAME   = 0x00000001;

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsFileAttributes.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsFileAttributes.java
@@ -107,6 +107,35 @@ class WindowsFileAttributes
     private static final short OFFSETOF_FIND_DATA_SIZELOW = 32;
     private static final short OFFSETOF_FIND_DATA_RESERVED0 = 36;
 
+    /*
+     * typedef struct _FILE_STAT_BASIC_INFORMATION {
+     *     LARGE_INTEGER FileId;                // 0
+     *     LARGE_INTEGER CreationTime;          // 8
+     *     LARGE_INTEGER LastAccessTime;        // 16
+     *     LARGE_INTEGER LastWriteTime;         // 24
+     *     LARGE_INTEGER ChangeTime;            // 32
+     *     LARGE_INTEGER AllocationSize;        // 40
+     *     LARGE_INTEGER EndOfFile;             // 48
+     *     ULONG         FileAttributes;        // 56
+     *     ULONG         ReparseTag;            // 60
+     *     ULONG         NumberOfLinks;         // 64
+     *     ULONG         DeviceType;            // 68
+     *     ULONG         DeviceCharacteristics; // 72
+     *     ULONG         Reserved;              // 76
+     *     LARGE_INTEGER VolumeSerialNumber;    // 80
+     *     FILE_ID_128   FileId128;             // 88
+     * } FILE_STAT_BASIC_INFORMATION;           // total: 104
+     */
+    static final short SIZEOF_STAT_BASIC_INFO = 104;
+    private static final short OFFSETOF_STAT_BASIC_INFO_CREATETIME      = 8;
+    private static final short OFFSETOF_STAT_BASIC_INFO_LASTACCESSTIME  = 16;
+    private static final short OFFSETOF_STAT_BASIC_INFO_LASTWRITETIME   = 24;
+    private static final short OFFSETOF_STAT_BASIC_INFO_ENDOFFILE       = 48;
+    private static final short OFFSETOF_STAT_BASIC_INFO_ATTRIBUTES      = 56;
+    private static final short OFFSETOF_STAT_BASIC_INFO_REPARSETAG      = 60;
+    private static final short OFFSETOF_STAT_BASIC_INFO_VOLSERIAL       = 80;
+    private static final short OFFSETOF_STAT_BASIC_INFO_FILEID128       = 88;
+
     // used to adjust values between Windows and java epochs
     private static final long WINDOWS_EPOCH_IN_MICROS = -11644473600000000L;
     private static final long WINDOWS_EPOCH_IN_100NS  = -116444736000000000L;
@@ -227,6 +256,39 @@ class WindowsFileAttributes
 
 
     /**
+     * Create a WindowsFileAttributes from a FILE_STAT_BASIC_INFORMATION structure
+     */
+    static WindowsFileAttributes fromStatBasicInfo(long address) {
+        int fileAttrs = unsafe.getInt(address + OFFSETOF_STAT_BASIC_INFO_ATTRIBUTES);
+        long creationTime = unsafe.getLong(address + OFFSETOF_STAT_BASIC_INFO_CREATETIME);
+        long lastAccessTime = unsafe.getLong(address + OFFSETOF_STAT_BASIC_INFO_LASTACCESSTIME);
+        long lastWriteTime = unsafe.getLong(address + OFFSETOF_STAT_BASIC_INFO_LASTWRITETIME);
+        long size = unsafe.getLong(address + OFFSETOF_STAT_BASIC_INFO_ENDOFFILE);
+        int reparseTag = isReparsePoint(fileAttrs) ?
+            unsafe.getInt(address + OFFSETOF_STAT_BASIC_INFO_REPARSETAG) : 0;
+
+        // VolumeSerialNumber is a LARGE_INTEGER, but Windows volume serial
+        // numbers are 32-bit values, so we take the low 32 bits.
+        int volSerialNumber = unsafe.getInt(address + OFFSETOF_STAT_BASIC_INFO_VOLSERIAL);
+
+        // FileId128: take the low 64 bits as two 32-bit halves for
+        // compatibility with the existing fileIndexHigh/fileIndexLow fields.
+        // On NTFS the upper 64 bits of FileId128 are zero.
+        int fileIndexLow = unsafe.getInt(address + OFFSETOF_STAT_BASIC_INFO_FILEID128);
+        int fileIndexHigh = unsafe.getInt(address + OFFSETOF_STAT_BASIC_INFO_FILEID128 + 4);
+
+        return new WindowsFileAttributes(fileAttrs,
+                                         creationTime,
+                                         lastAccessTime,
+                                         lastWriteTime,
+                                         size,
+                                         reparseTag,
+                                         volSerialNumber,
+                                         fileIndexHigh,
+                                         fileIndexLow);
+    }
+
+    /**
      * Allocates a native buffer for a WIN32_FIND_DATA structure
      */
     static NativeBuffer getBufferForFindData() {
@@ -328,6 +390,34 @@ class WindowsFileAttributes
                     return attrs;
                 } catch (WindowsException ignore) {
                     throw firstException;
+                }
+            }
+        }
+
+        // When ensureAccurateMetadata is true the GetFileAttributesEx fast
+        // path above is skipped, so this provides a handle-free alternative
+        // for non-reparse regular files.  When ensureAccurateMetadata is
+        // false, we only reach here for reparse-point entries (which will
+        // fall through since the API does not follow reparse points).
+        if (followLinks) {
+            try (NativeBuffer buffer =
+                NativeBuffers.getNativeBuffer(SIZEOF_STAT_BASIC_INFO)) {
+                long addr = buffer.address();
+                GetFileInformationByName(path.getPathForWin32Calls(),
+                                         FileStatBasicByNameInfo, addr,
+                                         SIZEOF_STAT_BASIC_INFO);
+                // `GetFileInformationByName()` does not follow reparse points.
+                // Instead it returns attributes of the directory entry itself.
+                // When `followLinks` is true and the entry is a reparse point,
+                // we need to open the file to get the target's attributes, so
+                // we fall through.
+                int fileAttrs = unsafe.getInt(addr + OFFSETOF_STAT_BASIC_INFO_ATTRIBUTES);
+                if (!isReparsePoint(fileAttrs)) {
+                    return fromStatBasicInfo(addr);
+                }
+            } catch (WindowsException exc) {
+                if (exc.lastError() != ERROR_NOT_SUPPORTED) {
+                    throw exc;
                 }
             }
         }

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsNativeDispatcher.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsNativeDispatcher.java
@@ -368,6 +368,24 @@ class WindowsNativeDispatcher {
         throws WindowsException;
 
     /**
+     * GetFileInformationByName(
+     *   PCWSTR                  FileName,
+     *   FILE_INFO_BY_NAME_CLASS FileInformationClass,
+     *   PVOID                   FileInfoBuffer,
+     *   ULONG                   FileInfoBufferSize
+     * )
+     */
+    static void GetFileInformationByName(String path, int infoClass, long address, int size)
+        throws WindowsException
+    {
+        try (NativeBuffer buffer = asNativeBuffer(path)) {
+            GetFileInformationByName0(buffer.address(), infoClass, address, size);
+        }
+    }
+    private static native void GetFileInformationByName0(long pathAddress,
+        int infoClass, long infoAddress, int infoSize) throws WindowsException;
+
+    /**
      * SetFileTime(
      *   HANDLE hFile,
      *   CONST FILETIME *lpCreationTime,

--- a/src/java.base/windows/native/libnio/fs/WindowsNativeDispatcher.c
+++ b/src/java.base/windows/native/libnio/fs/WindowsNativeDispatcher.c
@@ -510,6 +510,74 @@ Java_sun_nio_fs_WindowsNativeDispatcher_GetFileAttributesEx0(JNIEnv* env, jclass
         throwWindowsException(env, GetLastError());
 }
 
+// SDK-guarded definitions for GetFileInformationByName and related types.
+// Keep in sync with os_windows_fileinfo.hpp.
+#if !defined(NTDDI_WIN10_NI) || !(NTDDI_VERSION >= NTDDI_WIN10_NI)
+
+typedef struct _FILE_STAT_BASIC_INFORMATION {
+    LARGE_INTEGER FileId;
+    LARGE_INTEGER CreationTime;
+    LARGE_INTEGER LastAccessTime;
+    LARGE_INTEGER LastWriteTime;
+    LARGE_INTEGER ChangeTime;
+    LARGE_INTEGER AllocationSize;
+    LARGE_INTEGER EndOfFile;
+    ULONG         FileAttributes;
+    ULONG         ReparseTag;
+    ULONG         NumberOfLinks;
+    ULONG         DeviceType;
+    ULONG         DeviceCharacteristics;
+    ULONG         Reserved;
+    LARGE_INTEGER VolumeSerialNumber;
+    FILE_ID_128   FileId128;
+} FILE_STAT_BASIC_INFORMATION;
+
+typedef enum _FILE_INFO_BY_NAME_CLASS {
+    FileStatByNameInfo,
+    FileStatLxByNameInfo,
+    FileCaseSensitiveByNameInfo,
+    FileStatBasicByNameInfo,
+    MaximumFileInfoByNameClass
+} FILE_INFO_BY_NAME_CLASS;
+
+#endif /* !defined(NTDDI_WIN10_NI) || !(NTDDI_VERSION >= NTDDI_WIN10_NI) */
+
+typedef BOOL (WINAPI *PGetFileInformationByName)(
+    PCWSTR, FILE_INFO_BY_NAME_CLASS, PVOID, ULONG);
+
+static INIT_ONCE fileInfoByNameInitOnce = INIT_ONCE_STATIC_INIT;
+static PGetFileInformationByName pGetFileInformationByName = NULL;
+
+static BOOL CALLBACK initFileInfoByName(PINIT_ONCE initOnce, PVOID param, PVOID *context) {
+    // API present mentioned in:
+    // https://github.com/MicrosoftDocs/sdk-api/blob/docs/sdk-api-src/content/winbase/nf-winbase-getfileinformationbyname.md.
+    HMODULE hMod = LoadLibraryW(L"api-ms-win-core-file-l2-1-4");
+    if (hMod != NULL) {
+        pGetFileInformationByName =
+            (PGetFileInformationByName)GetProcAddress(hMod, "GetFileInformationByName");
+    }
+    return TRUE;
+}
+
+JNIEXPORT void JNICALL
+Java_sun_nio_fs_WindowsNativeDispatcher_GetFileInformationByName0(JNIEnv* env,
+    jclass this, jlong pathAddress, jint infoClass, jlong infoAddress, jint infoSize)
+{
+    LPCWSTR lpFileName = jlong_to_ptr(pathAddress);
+    PVOID pInfo = jlong_to_ptr(infoAddress);
+
+    InitOnceExecuteOnce(&fileInfoByNameInitOnce, initFileInfoByName, NULL, NULL);
+
+    if (pGetFileInformationByName == NULL) {
+        throwWindowsException(env, ERROR_NOT_SUPPORTED);
+        return;
+    }
+
+    if (!pGetFileInformationByName(lpFileName, (FILE_INFO_BY_NAME_CLASS)infoClass,
+                                   pInfo, (ULONG)infoSize)) {
+        throwWindowsException(env, GetLastError());
+    }
+}
 
 JNIEXPORT void JNICALL
 Java_sun_nio_fs_WindowsNativeDispatcher_SetFileTime0(JNIEnv* env, jclass this,

--- a/test/jdk/java/io/File/GetFileInformationByName.java
+++ b/test/jdk/java/io/File/GetFileInformationByName.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @summary Functional test for GetFileInformationByName fast paths
+ * @requires os.family == "windows"
+ * @run main GetFileInformationByName
+ */
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class GetFileInformationByName {
+
+    static int failures = 0;
+
+    static void check(boolean cond, String msg) {
+        if (!cond) {
+            System.err.println("FAIL: " + msg);
+            failures++;
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        Path dir = Files.createTempDirectory("gfinfo");
+        try {
+            testRegularFile(dir);
+            testDirectory(dir);
+            testNonExistent(dir);
+            testLargeFile(dir);
+            testSymlink(dir);
+            testIsSameFile(dir);
+        } finally {
+            try {
+                Files.walk(dir)
+                     .sorted(java.util.Comparator.reverseOrder())
+                     .forEach(p -> {
+                         try { Files.deleteIfExists(p); }
+                         catch (IOException ignore) {}
+                     });
+            } catch (IOException ignore) {}
+        }
+
+        if (failures > 0) {
+            throw new RuntimeException(failures + " test(s) failed");
+        }
+    }
+
+    static void testRegularFile(Path dir) throws Exception {
+        Path file = dir.resolve("regular.txt");
+        Files.writeString(file, "hello");
+
+        File f = file.toFile();
+        check(f.exists(),        "regular file should exist");
+        check(f.isFile(),        "should be a regular file");
+        check(!f.isDirectory(),  "should not be a directory");
+        check(f.length() == 5,   "length should be 5, got " + f.length());
+        check(f.canRead(),       "should be readable");
+        check(f.lastModified() > 0, "lastModified should be positive");
+    }
+
+    static void testDirectory(Path dir) throws Exception {
+        Path sub = dir.resolve("subdir");
+        Files.createDirectory(sub);
+
+        File d = sub.toFile();
+        check(d.exists(),        "directory should exist");
+        check(d.isDirectory(),   "should be a directory");
+        check(!d.isFile(),       "directory should not be a file");
+    }
+
+    static void testNonExistent(Path dir) throws Exception {
+        File ghost = dir.resolve("no_such_file.txt").toFile();
+        check(!ghost.exists(),     "ghost should not exist");
+        check(!ghost.isFile(),     "ghost should not be a file");
+        check(!ghost.isDirectory(),"ghost should not be a directory");
+        check(ghost.length() == 0, "ghost length should be 0");
+    }
+
+    static void testLargeFile(Path dir) throws Exception {
+        Path large = dir.resolve("large.bin");
+        long targetSize = 5L * 1024 * 1024 * 1024; // 5 GiB
+        try (var raf = new java.io.RandomAccessFile(large.toFile(), "rw")) {
+            raf.setLength(targetSize);
+        } catch (IOException e) {
+            System.out.println("  Skipped testLargeFile: " + e);
+            return;
+        }
+        try {
+            File f = large.toFile();
+            check(f.exists(), "large file should exist");
+            check(f.length() == targetSize,
+                  "large file length should be " + targetSize + ", got " + f.length());
+        } finally {
+            Files.deleteIfExists(large);
+        }
+    }
+
+    static void testSymlink(Path dir) throws Exception {
+        Path target = dir.resolve("symtarget.txt");
+        Files.writeString(target, "symlink content");
+        Path link = dir.resolve("symlink.lnk");
+
+        // We may run into unrelated failures when creating symbolic links
+        // (e.g. FAT32 does not support symbolic links or that the user may lack
+        // the privilge), so if we run into such problems, we just ignore them.
+        try {
+            Files.createSymbolicLink(link, target);
+        } catch (UnsupportedOperationException | IOException e) {
+            System.out.println("  Skipped: cannot create symlinks (" + e + ")");
+            return;
+        }
+
+        File lf = link.toFile();
+        check(lf.exists(),       "symlink should exist (follows target)");
+        check(lf.isFile(),       "symlink target should be a file");
+        check(!lf.isDirectory(), "symlink target should not be a directory");
+        check(lf.length() == 15,
+              "symlink target length should be 15, got " + lf.length());
+
+        var attrs = Files.readAttributes(link,
+                java.nio.file.attribute.BasicFileAttributes.class);
+        check(!attrs.isSymbolicLink(), "followLinks=true: not a symlink");
+        check(attrs.isRegularFile(),   "followLinks=true: regular file");
+        check(attrs.size() == 15,
+              "NIO size should be 15, got " + attrs.size());
+
+        var lattrs = Files.readAttributes(link,
+                java.nio.file.attribute.BasicFileAttributes.class,
+                java.nio.file.LinkOption.NOFOLLOW_LINKS);
+        check(lattrs.isSymbolicLink(), "nofollow: should be a symlink");
+    }
+
+    static void testIsSameFile(Path dir) throws Exception {
+        Path file1 = dir.resolve("samefile1.txt");
+        Path file2 = dir.resolve("samefile2.txt");
+        Files.writeString(file1, "a");
+        Files.writeString(file2, "b");
+
+        // Same path should be same file
+        check(Files.isSameFile(file1, file1),
+              "same path should be same file");
+
+        // Different files should not be same
+        check(!Files.isSameFile(file1, file2),
+              "different files should not be same file");
+
+        // Same file via different path (case variation on NTFS)
+        Path upper = dir.resolve("SAMEFILE1.TXT");
+        if (Files.exists(upper)) {
+            check(Files.isSameFile(file1, upper),
+                  "case-variant path should be same file on NTFS");
+        }
+
+        // isSameFile through a symlink
+        Path slink = dir.resolve("samelink");
+
+        // We may run into unrelated failures when creating symbolic links
+        // (e.g. FAT32 does not support symbolic links or that the user may lack
+        // the privilge), so if we run into such problems, we just ignore them.
+        try {
+            Files.createSymbolicLink(slink, file1);
+            check(Files.isSameFile(file1, slink),
+                  "symlink and target should be same file");
+            check(!Files.isSameFile(file2, slink),
+                  "symlink to file1 should not be same as file2");
+        } catch (UnsupportedOperationException | IOException e) {
+            System.out.println("  Symlink part skipped: " + e);
+        }
+    }
+}


### PR DESCRIPTION
On Linux, various `stat()` calls allow probing information about files
without opening them, but until recently, there wasn't an equivalent API
available on Windows.  Now that `GetFileInformationByName()` exists, we
can replace several instances of `GetFileInformationByHandle()`, which
required first opening the file to create a file handle, then reading
the file attributes, and finally closing the file handle, thus making
it slower than calling `GetFileInformationByName()`.

Since `GetFileInformationByName()` is available on only newer versions
of Windows, this patch uses conditional compilation and `LoadLibrary()`
/ `GetProcAddress()` to dynamically set the pointer to the API function.
If the dynamic loading fails, we fall back to the old API.  To avoid
problems with race conditions and weak memory ordering, we use Windows'
`INIT_ONCE` and `InitOnceExecuteOnce()` to initialize the function
pointer.

The rest of the patch is similar to the addition of any new JNI function
call.  WindowsConstants.java adds the relevant flags and error codes,
WindowsFileAttributes.java adds the Java entry point,
WindowsNativeDispatcher.java links the Java function with the C
function, and WindowsNativeDispatcher.c calls the Win32 API function.